### PR TITLE
Improve parallel state processor scheduling and add throughput benchmark

### DIFF
--- a/Core-Blockchain/node_src/core/parallel_state_processor.go
+++ b/Core-Blockchain/node_src/core/parallel_state_processor.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"runtime"
@@ -23,9 +24,10 @@ import (
 // ParallelStateProcessor extends StateProcessor with advanced parallel processing capabilities
 type ParallelStateProcessor struct {
 	*StateProcessor
-	processor       *gopool.ParallelProcessor
-	config          *ParallelProcessorConfig
-	
+	processor  *gopool.ParallelProcessor
+	config     *ParallelProcessorConfig
+	txExecutor txExecutorFunc
+
 	// Performance metrics
 	mu              sync.RWMutex
 	processedBlocks uint64
@@ -37,27 +39,27 @@ type ParallelStateProcessor struct {
 // ParallelProcessorConfig holds configuration for parallel state processing
 type ParallelProcessorConfig struct {
 	// Transaction processing
-	MaxTxConcurrency     int           `json:"maxTxConcurrency"`
-	TxBatchSize          int           `json:"txBatchSize"`
-	TxTimeout            time.Duration `json:"txTimeout"`
-	
+	MaxTxConcurrency int           `json:"maxTxConcurrency"`
+	TxBatchSize      int           `json:"txBatchSize"`
+	TxTimeout        time.Duration `json:"txTimeout"`
+
 	// Validation settings
 	MaxValidationWorkers int           `json:"maxValidationWorkers"`
 	ValidationTimeout    time.Duration `json:"validationTimeout"`
-	
+
 	// State processing
-	StateWorkers         int           `json:"stateWorkers"`
-	StateTimeout         time.Duration `json:"stateTimeout"`
-	
+	StateWorkers int           `json:"stateWorkers"`
+	StateTimeout time.Duration `json:"stateTimeout"`
+
 	// Performance tuning
-	EnablePipelining     bool          `json:"enablePipelining"`
-	EnableTxBatching     bool          `json:"enableTxBatching"`
-	EnableBloomParallel  bool          `json:"enableBloomParallel"`
-	AdaptiveScaling      bool          `json:"adaptiveScaling"`
-	
+	EnablePipelining    bool `json:"enablePipelining"`
+	EnableTxBatching    bool `json:"enableTxBatching"`
+	EnableBloomParallel bool `json:"enableBloomParallel"`
+	AdaptiveScaling     bool `json:"adaptiveScaling"`
+
 	// Resource limits
-	MaxMemoryUsage       uint64        `json:"maxMemoryUsage"`
-	MaxGoroutines        int           `json:"maxGoroutines"`
+	MaxMemoryUsage uint64 `json:"maxMemoryUsage"`
+	MaxGoroutines  int    `json:"maxGoroutines"`
 }
 
 // DefaultParallelProcessorConfig returns optimized default configuration
@@ -85,10 +87,10 @@ func NewParallelStateProcessor(config *params.ChainConfig, bc *BlockChain, engin
 	if parallelConfig == nil {
 		parallelConfig = DefaultParallelProcessorConfig()
 	}
-	
+
 	// Create base state processor
 	baseProcessor := NewStateProcessor(config, bc, engine)
-	
+
 	// Initialize parallel processor
 	processorConfig := &gopool.ProcessorConfig{
 		MaxWorkers:        parallelConfig.MaxGoroutines,
@@ -100,19 +102,23 @@ func NewParallelStateProcessor(config *params.ChainConfig, bc *BlockChain, engin
 		ConsensusWorkers:  runtime.NumCPU() / 2,
 		NetworkWorkers:    runtime.NumCPU(),
 	}
-	
+
 	processor, err := gopool.NewParallelProcessor(processorConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create parallel processor: %w", err)
 	}
-	
+
 	psp := &ParallelStateProcessor{
 		StateProcessor: baseProcessor,
 		processor:      processor,
 		config:         parallelConfig,
 		maxConcurrency: int32(parallelConfig.MaxTxConcurrency),
 	}
-	
+
+	psp.txExecutor = func(msg types.Message, chainCfg *params.ChainConfig, chainCtx ChainContext, author *common.Address, gp *GasPool, statedb *state.StateDB, blockNumber *big.Int, blockHash common.Hash, tx *types.Transaction, usedGas *uint64, evm *vm.EVM, bloomWg *sync.WaitGroup) (*types.Receipt, error) {
+		return psp.applyTransactionParallel(msg, chainCfg, chainCtx, author, gp, statedb, blockNumber, blockHash, tx, usedGas, evm, bloomWg)
+	}
+
 	log.Info("Parallel state processor initialized",
 		"maxTxConcurrency", parallelConfig.MaxTxConcurrency,
 		"txBatchSize", parallelConfig.TxBatchSize,
@@ -121,7 +127,7 @@ func NewParallelStateProcessor(config *params.ChainConfig, bc *BlockChain, engin
 		"pipelining", parallelConfig.EnablePipelining,
 		"batching", parallelConfig.EnableTxBatching,
 	)
-	
+
 	return psp, nil
 }
 
@@ -138,7 +144,7 @@ func (psp *ParallelStateProcessor) ProcessParallel(block *types.Block, statedb *
 			"tps", float64(len(block.Transactions()))/duration.Seconds(),
 		)
 	}()
-	
+
 	var (
 		receipts    = make([]*types.Receipt, 0, len(block.Transactions()))
 		usedGas     = new(uint64)
@@ -148,11 +154,11 @@ func (psp *ParallelStateProcessor) ProcessParallel(block *types.Block, statedb *
 		allLogs     []*types.Log
 		gp          = new(GasPool).AddGas(block.GasLimit())
 	)
-	
+
 	// Create EVM context
 	blockContext := NewEVMBlockContext(header, psp.bc, nil)
 	vmenv := vm.NewEVM(blockContext, vm.TxContext{}, statedb, psp.StateProcessor.config, cfg)
-	
+
 	// Handle PoSA consensus if applicable
 	posa, isPoSA := psp.engine.(consensus.PoSA)
 	if isPoSA {
@@ -161,17 +167,17 @@ func (psp *ParallelStateProcessor) ProcessParallel(block *types.Block, statedb *
 		}
 		vmenv.Context.ExtraValidator = posa.CreateEvmExtraValidator(header, statedb)
 	}
-	
+
 	// Preload accounts for better performance
 	signer := types.MakeSigner(psp.StateProcessor.config, header.Number)
 	statedb.PreloadAccounts(block, signer)
-	
+
 	// Separate system and regular transactions
 	commonTxs, systemTxs, err := psp.separateTransactions(block.Transactions(), signer, header, isPoSA, posa)
 	if err != nil {
 		return nil, nil, 0, err
 	}
-	
+
 	// Process transactions based on configuration
 	if psp.config.EnableTxBatching && len(commonTxs) > psp.config.TxBatchSize {
 		receipts, allLogs, err = psp.processBatchedTransactions(commonTxs, statedb, vmenv, gp, usedGas, blockNumber, blockHash)
@@ -180,16 +186,16 @@ func (psp *ParallelStateProcessor) ProcessParallel(block *types.Block, statedb *
 	} else {
 		receipts, allLogs, err = psp.processSequentialTransactions(commonTxs, statedb, vmenv, gp, usedGas, blockNumber, blockHash)
 	}
-	
+
 	if err != nil {
 		return nil, nil, 0, err
 	}
-	
+
 	// Finalize the block
 	if err := psp.engine.Finalize(psp.bc, header, statedb, &commonTxs, block.Uncles(), &receipts, systemTxs); err != nil {
 		return nil, nil, 0, err
 	}
-	
+
 	return receipts, allLogs, *usedGas, nil
 }
 
@@ -197,19 +203,19 @@ func (psp *ParallelStateProcessor) ProcessParallel(block *types.Block, statedb *
 func (psp *ParallelStateProcessor) separateTransactions(txs []*types.Transaction, signer types.Signer, header *types.Header, isPoSA bool, posa consensus.PoSA) ([]*types.Transaction, []*types.Transaction, error) {
 	commonTxs := make([]*types.Transaction, 0, len(txs))
 	systemTxs := make([]*types.Transaction, 0)
-	
+
 	for _, tx := range txs {
 		if isPoSA {
 			sender, err := types.Sender(signer, tx)
 			if err != nil {
 				return nil, nil, err
 			}
-			
+
 			ok, err := posa.IsSysTransaction(sender, tx, header)
 			if err != nil {
 				return nil, nil, err
 			}
-			
+
 			if ok {
 				systemTxs = append(systemTxs, tx)
 				continue
@@ -217,37 +223,119 @@ func (psp *ParallelStateProcessor) separateTransactions(txs []*types.Transaction
 		}
 		commonTxs = append(commonTxs, tx)
 	}
-	
+
 	return commonTxs, systemTxs, nil
 }
 
 // processBatchedTransactions processes transactions in parallel batches
+var errBatchAborted = errors.New("batch processing aborted")
+
 func (psp *ParallelStateProcessor) processBatchedTransactions(txs []*types.Transaction, statedb *state.StateDB, vmenv *vm.EVM, gp *GasPool, usedGas *uint64, blockNumber *big.Int, blockHash common.Hash) ([]*types.Receipt, []*types.Log, error) {
 	receipts := make([]*types.Receipt, len(txs))
 	allLogs := make([]*types.Log, 0)
-	
+
+	if len(txs) == 0 {
+		return receipts, allLogs, nil
+	}
+
 	batchSize := psp.config.TxBatchSize
+	if batchSize <= 0 {
+		batchSize = len(txs)
+	}
 	numBatches := (len(txs) + batchSize - 1) / batchSize
-	
-	// Process batches sequentially to maintain state consistency
+
+	var (
+		wg       sync.WaitGroup
+		mu       sync.Mutex
+		cond     = sync.NewCond(&mu)
+		next     = 0
+		firstErr error
+	)
+
+	appendLogs := func(logs []*types.Log) {
+		allLogs = append(allLogs, logs...)
+	}
+
 	for batchIdx := 0; batchIdx < numBatches; batchIdx++ {
 		start := batchIdx * batchSize
 		end := start + batchSize
 		if end > len(txs) {
 			end = len(txs)
 		}
-		
+
 		batchTxs := txs[start:end]
-		batchReceipts, batchLogs, err := psp.processBatch(batchTxs, start, statedb, vmenv, gp, usedGas, blockNumber, blockHash)
-		if err != nil {
+
+		wg.Add(1)
+		idx := batchIdx
+		task := &gopool.Task{
+			Type: gopool.TaskTypeState,
+			Fn: func() error {
+				mu.Lock()
+				for idx != next && firstErr == nil {
+					cond.Wait()
+				}
+
+				if firstErr != nil {
+					mu.Unlock()
+					return errBatchAborted
+				}
+
+				gasBefore := gp.Gas()
+				prevUsedGas := *usedGas
+				snapshot := statedb.Snapshot()
+
+				batchReceipts, batchLogs, err := psp.processBatch(batchTxs, start, statedb, vmenv, gp, usedGas, blockNumber, blockHash)
+				if err != nil {
+					*usedGas = prevUsedGas
+					*gp = GasPool(gasBefore)
+					statedb.RevertToSnapshot(snapshot)
+					if firstErr == nil {
+						firstErr = err
+					}
+					cond.Broadcast()
+					mu.Unlock()
+					return err
+				}
+
+				copy(receipts[start:end], batchReceipts)
+				appendLogs(batchLogs)
+
+				next++
+				cond.Broadcast()
+				mu.Unlock()
+				return nil
+			},
+			OnComplete: func(err error) {
+				if err != nil && !errors.Is(err, errBatchAborted) {
+					mu.Lock()
+					if firstErr == nil {
+						firstErr = err
+					}
+					cond.Broadcast()
+					mu.Unlock()
+				}
+				wg.Done()
+			},
+		}
+
+		if err := psp.processor.SubmitTask(task); err != nil {
+			wg.Done()
+			mu.Lock()
+			if firstErr == nil {
+				firstErr = err
+			}
+			cond.Broadcast()
+			mu.Unlock()
 			return nil, nil, err
 		}
-		
-		// Copy results
-		copy(receipts[start:end], batchReceipts)
-		allLogs = append(allLogs, batchLogs...)
 	}
-	
+
+	wg.Wait()
+
+	if firstErr != nil {
+		return nil, nil, firstErr
+	}
+
 	return receipts, allLogs, nil
 }
 
@@ -255,31 +343,31 @@ func (psp *ParallelStateProcessor) processBatchedTransactions(txs []*types.Trans
 func (psp *ParallelStateProcessor) processBatch(txs []*types.Transaction, startIdx int, statedb *state.StateDB, vmenv *vm.EVM, gp *GasPool, usedGas *uint64, blockNumber *big.Int, blockHash common.Hash) ([]*types.Receipt, []*types.Log, error) {
 	receipts := make([]*types.Receipt, len(txs))
 	allLogs := make([]*types.Log, 0)
-	
+
 	var bloomWg sync.WaitGroup
-	
+
 	// Process transactions sequentially within batch (for state consistency)
 	for i, tx := range txs {
 		msg, err := tx.AsMessage(types.MakeSigner(psp.StateProcessor.config, blockNumber), nil)
 		if err != nil {
 			return nil, nil, fmt.Errorf("could not apply tx %d [%v]: %w", startIdx+i, tx.Hash().Hex(), err)
 		}
-		
+
 		statedb.Prepare(tx.Hash(), startIdx+i)
-		
+
 		// Apply transaction
-		receipt, err := psp.applyTransactionParallel(msg, psp.StateProcessor.config, psp.bc, nil, gp, statedb, blockNumber, blockHash, tx, usedGas, vmenv, &bloomWg)
+		receipt, err := psp.executeTransaction(msg, psp.StateProcessor.config, psp.bc, nil, gp, statedb, blockNumber, blockHash, tx, usedGas, vmenv, &bloomWg)
 		if err != nil {
 			return nil, nil, fmt.Errorf("could not apply tx %d [%v]: %w", startIdx+i, tx.Hash().Hex(), err)
 		}
-		
+
 		receipts[i] = receipt
 		allLogs = append(allLogs, receipt.Logs...)
 	}
-	
+
 	// Wait for all bloom filters to be created
 	bloomWg.Wait()
-	
+
 	return receipts, allLogs, nil
 }
 
@@ -287,15 +375,15 @@ func (psp *ParallelStateProcessor) processBatch(txs []*types.Transaction, startI
 func (psp *ParallelStateProcessor) processPipelinedTransactions(txs []*types.Transaction, statedb *state.StateDB, vmenv *vm.EVM, gp *GasPool, usedGas *uint64, blockNumber *big.Int, blockHash common.Hash) ([]*types.Receipt, []*types.Log, error) {
 	receipts := make([]*types.Receipt, len(txs))
 	allLogs := make([]*types.Log, 0)
-	
+
 	// Pipeline stages: validation -> execution -> bloom creation
 	validationCh := make(chan *txValidationResult, psp.config.MaxTxConcurrency)
 	executionCh := make(chan *txExecutionResult, psp.config.MaxTxConcurrency)
-	
+
 	var wg sync.WaitGroup
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	
+
 	// Stage 1: Transaction validation
 	wg.Add(1)
 	go func() {
@@ -303,7 +391,7 @@ func (psp *ParallelStateProcessor) processPipelinedTransactions(txs []*types.Tra
 		defer close(validationCh)
 		psp.validateTransactionsPipeline(ctx, txs, blockNumber, validationCh)
 	}()
-	
+
 	// Stage 2: Transaction execution
 	wg.Add(1)
 	go func() {
@@ -311,16 +399,16 @@ func (psp *ParallelStateProcessor) processPipelinedTransactions(txs []*types.Tra
 		defer close(executionCh)
 		psp.executeTransactionsPipeline(ctx, validationCh, statedb, vmenv, gp, usedGas, blockNumber, blockHash, executionCh)
 	}()
-	
+
 	// Stage 3: Result collection and bloom creation
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		psp.collectResultsPipeline(ctx, executionCh, receipts, &allLogs)
 	}()
-	
+
 	wg.Wait()
-	
+
 	return receipts, allLogs, nil
 }
 
@@ -328,26 +416,26 @@ func (psp *ParallelStateProcessor) processPipelinedTransactions(txs []*types.Tra
 func (psp *ParallelStateProcessor) processSequentialTransactions(txs []*types.Transaction, statedb *state.StateDB, vmenv *vm.EVM, gp *GasPool, usedGas *uint64, blockNumber *big.Int, blockHash common.Hash) ([]*types.Receipt, []*types.Log, error) {
 	receipts := make([]*types.Receipt, len(txs))
 	allLogs := make([]*types.Log, 0)
-	
+
 	var bloomWg sync.WaitGroup
-	
+
 	for i, tx := range txs {
 		msg, err := tx.AsMessage(types.MakeSigner(psp.StateProcessor.config, blockNumber), nil)
 		if err != nil {
 			return nil, nil, fmt.Errorf("could not apply tx %d [%v]: %w", i, tx.Hash().Hex(), err)
 		}
-		
+
 		statedb.Prepare(tx.Hash(), i)
-		
+
 		receipt, err := psp.applyTransactionParallel(msg, psp.StateProcessor.config, psp.bc, nil, gp, statedb, blockNumber, blockHash, tx, usedGas, vmenv, &bloomWg)
 		if err != nil {
 			return nil, nil, fmt.Errorf("could not apply tx %d [%v]: %w", i, tx.Hash().Hex(), err)
 		}
-		
+
 		receipts[i] = receipt
 		allLogs = append(allLogs, receipt.Logs...)
 	}
-	
+
 	bloomWg.Wait()
 	return receipts, allLogs, nil
 }
@@ -357,13 +445,13 @@ func (psp *ParallelStateProcessor) applyTransactionParallel(msg types.Message, c
 	// Create a new context to be used in the EVM environment
 	txContext := NewEVMTxContext(msg)
 	evm.Reset(txContext, statedb)
-	
+
 	// Apply the transaction to the current state
 	result, err := ApplyMessage(evm, msg, gp)
 	if err != nil {
 		return nil, err
 	}
-	
+
 	// Update the state with pending changes
 	var root []byte
 	if config.IsByzantium(blockNumber) {
@@ -372,7 +460,7 @@ func (psp *ParallelStateProcessor) applyTransactionParallel(msg types.Message, c
 		root = statedb.IntermediateRoot(config.IsEIP158(blockNumber)).Bytes()
 	}
 	*usedGas += result.UsedGas
-	
+
 	// Create receipt
 	receipt := &types.Receipt{Type: tx.Type(), PostState: root, CumulativeGasUsed: *usedGas}
 	if result.Failed() {
@@ -382,18 +470,18 @@ func (psp *ParallelStateProcessor) applyTransactionParallel(msg types.Message, c
 	}
 	receipt.TxHash = tx.Hash()
 	receipt.GasUsed = result.UsedGas
-	
+
 	// Set contract address if contract creation
 	if msg.To() == nil {
 		receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, tx.Nonce())
 	}
-	
+
 	// Set logs and create bloom filter
 	receipt.Logs = statedb.GetLogs(tx.Hash(), blockHash)
 	receipt.BlockHash = blockHash
 	receipt.BlockNumber = blockNumber
 	receipt.TransactionIndex = uint(statedb.TxIndex())
-	
+
 	// Create bloom filter in parallel if enabled
 	if psp.config.EnableBloomParallel && bloomWg != nil {
 		bloomWg.Add(1)
@@ -413,7 +501,7 @@ func (psp *ParallelStateProcessor) applyTransactionParallel(msg types.Message, c
 	} else {
 		receipt.Bloom = types.CreateBloom(types.Receipts{receipt})
 	}
-	
+
 	return receipt, nil
 }
 
@@ -432,16 +520,25 @@ type txExecutionResult struct {
 	err     error
 }
 
+type txExecutorFunc func(msg types.Message, config *params.ChainConfig, bc ChainContext, author *common.Address, gp *GasPool, statedb *state.StateDB, blockNumber *big.Int, blockHash common.Hash, tx *types.Transaction, usedGas *uint64, evm *vm.EVM, bloomWg *sync.WaitGroup) (*types.Receipt, error)
+
+func (psp *ParallelStateProcessor) executeTransaction(msg types.Message, config *params.ChainConfig, bc ChainContext, author *common.Address, gp *GasPool, statedb *state.StateDB, blockNumber *big.Int, blockHash common.Hash, tx *types.Transaction, usedGas *uint64, evm *vm.EVM, bloomWg *sync.WaitGroup) (*types.Receipt, error) {
+	if psp.txExecutor != nil {
+		return psp.txExecutor(msg, config, bc, author, gp, statedb, blockNumber, blockHash, tx, usedGas, evm, bloomWg)
+	}
+	return psp.applyTransactionParallel(msg, config, bc, author, gp, statedb, blockNumber, blockHash, tx, usedGas, evm, bloomWg)
+}
+
 func (psp *ParallelStateProcessor) validateTransactionsPipeline(ctx context.Context, txs []*types.Transaction, blockNumber *big.Int, output chan<- *txValidationResult) {
 	signer := types.MakeSigner(psp.StateProcessor.config, blockNumber)
-	
+
 	for i, tx := range txs {
 		select {
 		case <-ctx.Done():
 			return
 		default:
 		}
-		
+
 		msg, err := tx.AsMessage(signer, nil)
 		result := &txValidationResult{
 			index: i,
@@ -449,7 +546,7 @@ func (psp *ParallelStateProcessor) validateTransactionsPipeline(ctx context.Cont
 			msg:   msg,
 			err:   err,
 		}
-		
+
 		select {
 		case output <- result:
 		case <-ctx.Done():
@@ -459,49 +556,108 @@ func (psp *ParallelStateProcessor) validateTransactionsPipeline(ctx context.Cont
 }
 
 func (psp *ParallelStateProcessor) executeTransactionsPipeline(ctx context.Context, input <-chan *txValidationResult, statedb *state.StateDB, vmenv *vm.EVM, gp *GasPool, usedGas *uint64, blockNumber *big.Int, blockHash common.Hash, output chan<- *txExecutionResult) {
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case validation, ok := <-input:
-			if !ok {
-				return
-			}
-			
-			if validation.err != nil {
-				result := &txExecutionResult{
-					index: validation.index,
-					err:   validation.err,
-				}
-				select {
-				case output <- result:
-				case <-ctx.Done():
-					return
-				}
-				continue
-			}
-			
-			statedb.Prepare(validation.tx.Hash(), validation.index)
-			
-			receipt, err := psp.applyTransactionParallel(validation.msg, psp.StateProcessor.config, psp.bc, nil, gp, statedb, blockNumber, blockHash, validation.tx, usedGas, vmenv, nil)
-			
-			result := &txExecutionResult{
-				index:   validation.index,
-				receipt: receipt,
-				err:     err,
-			}
-			
-			if receipt != nil {
-				result.logs = receipt.Logs
-			}
-			
-			select {
-			case output <- result:
-			case <-ctx.Done():
-				return
-			}
-		}
+	workerCount := psp.config.MaxTxConcurrency
+	if workerCount <= 0 {
+		workerCount = 1
 	}
+
+	var (
+		wg     sync.WaitGroup
+		mu     sync.Mutex
+		cond   = sync.NewCond(&mu)
+		next   = 0
+		halted bool
+	)
+
+	signalHalt := func() {
+		mu.Lock()
+		halted = true
+		cond.Broadcast()
+		mu.Unlock()
+	}
+
+	for i := 0; i < workerCount; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					signalHalt()
+					return
+				case validation, ok := <-input:
+					if !ok {
+						signalHalt()
+						return
+					}
+
+					mu.Lock()
+					for validation.index != next && !halted {
+						cond.Wait()
+					}
+					if halted {
+						mu.Unlock()
+						return
+					}
+
+					if validation.err != nil {
+						next++
+						cond.Broadcast()
+						mu.Unlock()
+
+						result := &txExecutionResult{
+							index: validation.index,
+							err:   validation.err,
+						}
+
+						select {
+						case output <- result:
+						case <-ctx.Done():
+							signalHalt()
+							return
+						}
+						continue
+					}
+
+					gasBefore := gp.Gas()
+					prevUsedGas := *usedGas
+					snapshot := statedb.Snapshot()
+
+					statedb.Prepare(validation.tx.Hash(), validation.index)
+					receipt, err := psp.executeTransaction(validation.msg, psp.StateProcessor.config, psp.bc, nil, gp, statedb, blockNumber, blockHash, validation.tx, usedGas, vmenv, nil)
+
+					if err != nil {
+						*usedGas = prevUsedGas
+						*gp = GasPool(gasBefore)
+						statedb.RevertToSnapshot(snapshot)
+					}
+
+					next++
+					cond.Broadcast()
+					mu.Unlock()
+
+					result := &txExecutionResult{
+						index:   validation.index,
+						receipt: receipt,
+						err:     err,
+					}
+
+					if receipt != nil {
+						result.logs = receipt.Logs
+					}
+
+					select {
+					case output <- result:
+					case <-ctx.Done():
+						signalHalt()
+						return
+					}
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
 }
 
 func (psp *ParallelStateProcessor) collectResultsPipeline(ctx context.Context, input <-chan *txExecutionResult, receipts []*types.Receipt, allLogs *[]*types.Log) {
@@ -513,12 +669,12 @@ func (psp *ParallelStateProcessor) collectResultsPipeline(ctx context.Context, i
 			if !ok {
 				return
 			}
-			
+
 			if result.err != nil {
 				log.Error("Transaction execution failed", "index", result.index, "err", result.err)
 				continue
 			}
-			
+
 			receipts[result.index] = result.receipt
 			*allLogs = append(*allLogs, result.logs...)
 		}
@@ -529,14 +685,14 @@ func (psp *ParallelStateProcessor) collectResultsPipeline(ctx context.Context, i
 func (psp *ParallelStateProcessor) updateMetrics(duration time.Duration) {
 	psp.mu.Lock()
 	defer psp.mu.Unlock()
-	
+
 	psp.processedBlocks++
 	if psp.avgBlockTime == 0 {
 		psp.avgBlockTime = duration
 	} else {
 		psp.avgBlockTime = (psp.avgBlockTime + duration) / 2
 	}
-	
+
 	// Adaptive scaling based on performance
 	if psp.config.AdaptiveScaling {
 		psp.adjustConcurrency(duration)
@@ -545,14 +701,14 @@ func (psp *ParallelStateProcessor) updateMetrics(duration time.Duration) {
 
 func (psp *ParallelStateProcessor) adjustConcurrency(duration time.Duration) {
 	currentConcurrency := atomic.LoadInt32(&psp.maxConcurrency)
-	
+
 	// If processing is too slow, reduce concurrency to avoid overhead
 	if duration > 5*time.Second && currentConcurrency > 1 {
 		newConcurrency := currentConcurrency * 8 / 10 // Reduce by 20%
 		atomic.StoreInt32(&psp.maxConcurrency, newConcurrency)
 		log.Debug("Reduced concurrency due to slow processing", "old", currentConcurrency, "new", newConcurrency)
 	}
-	
+
 	// If processing is fast and we have capacity, increase concurrency
 	if duration < 1*time.Second && currentConcurrency < int32(psp.config.MaxTxConcurrency) {
 		newConcurrency := currentConcurrency * 11 / 10 // Increase by 10%
@@ -568,22 +724,22 @@ func (psp *ParallelStateProcessor) adjustConcurrency(duration time.Duration) {
 func (psp *ParallelStateProcessor) GetStats() ParallelProcessorStats {
 	psp.mu.RLock()
 	defer psp.mu.RUnlock()
-	
+
 	processorStats := psp.processor.GetStats()
-	
+
 	return ParallelProcessorStats{
-		ProcessedBlocks:   psp.processedBlocks,
-		AvgBlockTime:      psp.avgBlockTime,
+		ProcessedBlocks:    psp.processedBlocks,
+		AvgBlockTime:       psp.avgBlockTime,
 		CurrentConcurrency: atomic.LoadInt32(&psp.maxConcurrency),
-		ProcessorStats:    processorStats,
+		ProcessorStats:     processorStats,
 	}
 }
 
 type ParallelProcessorStats struct {
-	ProcessedBlocks     uint64                  `json:"processedBlocks"`
-	AvgBlockTime        time.Duration           `json:"avgBlockTime"`
-	CurrentConcurrency  int32                   `json:"currentConcurrency"`
-	ProcessorStats      gopool.ProcessorStats   `json:"processorStats"`
+	ProcessedBlocks    uint64                `json:"processedBlocks"`
+	AvgBlockTime       time.Duration         `json:"avgBlockTime"`
+	CurrentConcurrency int32                 `json:"currentConcurrency"`
+	ProcessorStats     gopool.ProcessorStats `json:"processorStats"`
 }
 
 // Close shuts down the parallel processor

--- a/Core-Blockchain/node_src/core/parallel_state_processor_bench_test.go
+++ b/Core-Blockchain/node_src/core/parallel_state_processor_bench_test.go
@@ -1,0 +1,123 @@
+package core
+
+import (
+	"fmt"
+	"math/big"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/gopool"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+func BenchmarkParallelStateProcessorPipeline(b *testing.B) {
+	txCount := 120000
+	chainCfg := params.TestChainConfig
+
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		b.Fatalf("failed to generate key: %v", err)
+	}
+	from := crypto.PubkeyToAddress(key.PublicKey)
+	to := common.HexToAddress("0x000000000000000000000000000000000000dead")
+
+	db := rawdb.NewMemoryDatabase()
+	stateDB, err := state.New(common.Hash{}, state.NewDatabase(db), nil)
+	if err != nil {
+		b.Fatalf("failed to create state: %v", err)
+	}
+	stateDB.CreateAccount(from)
+	stateDB.AddBalance(from, big.NewInt(0).Mul(big.NewInt(1e18), big.NewInt(int64(txCount))))
+
+	txs := make([]*types.Transaction, txCount)
+	signer := types.MakeSigner(chainCfg, big.NewInt(1))
+	gasLimit := uint64(50000)
+	gasUsedPerTx := uint64(21000)
+
+	for i := 0; i < txCount; i++ {
+		unsigned := types.NewTransaction(uint64(i), to, big.NewInt(1), gasLimit, big.NewInt(1), nil)
+		signed, signErr := types.SignTx(unsigned, signer, key)
+		if signErr != nil {
+			b.Fatalf("failed to sign tx: %v", signErr)
+		}
+		txs[i] = signed
+	}
+
+	baseState := stateDB
+	blockHash := common.HexToHash("0x1234")
+	blockNumber := big.NewInt(1)
+	blockGasLimit := uint64(txCount) * gasLimit
+
+	createProcessor := func(workers int) *ParallelStateProcessor {
+		parallelCfg := DefaultParallelProcessorConfig()
+		parallelCfg.EnableTxBatching = false
+		parallelCfg.EnableBloomParallel = false
+		parallelCfg.EnablePipelining = true
+		parallelCfg.MaxTxConcurrency = workers
+		parallelCfg.TxBatchSize = 1024
+		parallelCfg.MaxValidationWorkers = workers
+		parallelCfg.MaxGoroutines = runtime.NumCPU() * 2
+		parallelCfg.StateWorkers = runtime.NumCPU()
+		processorCfg := &gopool.ProcessorConfig{
+			MaxWorkers:        parallelCfg.MaxGoroutines,
+			QueueSize:         1 << 14,
+			Timeout:           time.Second,
+			TxWorkers:         parallelCfg.MaxTxConcurrency,
+			ValidationWorkers: parallelCfg.MaxValidationWorkers,
+			StateWorkers:      parallelCfg.StateWorkers,
+		}
+		processor, err := gopool.NewParallelProcessor(processorCfg)
+		if err != nil {
+			b.Fatalf("failed to construct processor: %v", err)
+		}
+		psp := &ParallelStateProcessor{
+			StateProcessor: &StateProcessor{config: chainCfg},
+			processor:      processor,
+			config:         parallelCfg,
+			maxConcurrency: int32(workers),
+		}
+		psp.txExecutor = func(_ types.Message, _ *params.ChainConfig, _ ChainContext, _ *common.Address, _ *GasPool, _ *state.StateDB, _ *big.Int, _ common.Hash, tx *types.Transaction, usedGas *uint64, _ *vm.EVM, _ *sync.WaitGroup) (*types.Receipt, error) {
+			time.Sleep(50 * time.Microsecond)
+			*usedGas += gasUsedPerTx
+			receipt := &types.Receipt{
+				Type:              tx.Type(),
+				CumulativeGasUsed: *usedGas,
+				GasUsed:           gasUsedPerTx,
+				TxHash:            tx.Hash(),
+				BlockHash:         blockHash,
+				BlockNumber:       blockNumber,
+			}
+			return receipt, nil
+		}
+		return psp
+	}
+
+	workers := []int{1, runtime.NumCPU()}
+	for _, w := range workers {
+		b.Run(fmt.Sprintf("workers_%d", w), func(b *testing.B) {
+			psp := createProcessor(w)
+			b.Cleanup(func() {
+				_ = psp.processor.Close()
+			})
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				stateCopy := baseState.Copy()
+				gp := new(GasPool).AddGas(blockGasLimit)
+				used := new(uint64)
+				_, _, err := psp.processPipelinedTransactions(txs, stateCopy, nil, gp, used, blockNumber, blockHash)
+				if err != nil {
+					b.Fatalf("pipeline execution failed: %v", err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- dispatch transaction batches through the shared parallel processor using ordered worker coordination and state snapshots
- allow injection of a custom executor while spawning bounded worker goroutines for the pipelined execution stage
- add a benchmark that exercises >100K synthetic transactions and compares single-worker vs. multi-worker pipeline throughput

## Testing
- `GO111MODULE=off go test ./Core-Blockchain/node_src/core -run TestDoesNotExist` *(fails: missing go-ethereum dependencies in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc26451b0c83249cb65efe5c4299ab