### PR TITLE
Offload GPU batches to parallel CPU executor

### DIFF
--- a/Core-Blockchain/node_src/core/parallel_state_processor.go
+++ b/Core-Blockchain/node_src/core/parallel_state_processor.go
@@ -23,9 +23,9 @@ import (
 // ParallelStateProcessor extends StateProcessor with advanced parallel processing capabilities
 type ParallelStateProcessor struct {
 	*StateProcessor
-	processor       *gopool.ParallelProcessor
-	config          *ParallelProcessorConfig
-	
+	processor *gopool.ParallelProcessor
+	config    *ParallelProcessorConfig
+
 	// Performance metrics
 	mu              sync.RWMutex
 	processedBlocks uint64
@@ -37,27 +37,27 @@ type ParallelStateProcessor struct {
 // ParallelProcessorConfig holds configuration for parallel state processing
 type ParallelProcessorConfig struct {
 	// Transaction processing
-	MaxTxConcurrency     int           `json:"maxTxConcurrency"`
-	TxBatchSize          int           `json:"txBatchSize"`
-	TxTimeout            time.Duration `json:"txTimeout"`
-	
+	MaxTxConcurrency int           `json:"maxTxConcurrency"`
+	TxBatchSize      int           `json:"txBatchSize"`
+	TxTimeout        time.Duration `json:"txTimeout"`
+
 	// Validation settings
 	MaxValidationWorkers int           `json:"maxValidationWorkers"`
 	ValidationTimeout    time.Duration `json:"validationTimeout"`
-	
+
 	// State processing
-	StateWorkers         int           `json:"stateWorkers"`
-	StateTimeout         time.Duration `json:"stateTimeout"`
-	
+	StateWorkers int           `json:"stateWorkers"`
+	StateTimeout time.Duration `json:"stateTimeout"`
+
 	// Performance tuning
-	EnablePipelining     bool          `json:"enablePipelining"`
-	EnableTxBatching     bool          `json:"enableTxBatching"`
-	EnableBloomParallel  bool          `json:"enableBloomParallel"`
-	AdaptiveScaling      bool          `json:"adaptiveScaling"`
-	
+	EnablePipelining    bool `json:"enablePipelining"`
+	EnableTxBatching    bool `json:"enableTxBatching"`
+	EnableBloomParallel bool `json:"enableBloomParallel"`
+	AdaptiveScaling     bool `json:"adaptiveScaling"`
+
 	// Resource limits
-	MaxMemoryUsage       uint64        `json:"maxMemoryUsage"`
-	MaxGoroutines        int           `json:"maxGoroutines"`
+	MaxMemoryUsage uint64 `json:"maxMemoryUsage"`
+	MaxGoroutines  int    `json:"maxGoroutines"`
 }
 
 // DefaultParallelProcessorConfig returns optimized default configuration
@@ -85,10 +85,10 @@ func NewParallelStateProcessor(config *params.ChainConfig, bc *BlockChain, engin
 	if parallelConfig == nil {
 		parallelConfig = DefaultParallelProcessorConfig()
 	}
-	
+
 	// Create base state processor
 	baseProcessor := NewStateProcessor(config, bc, engine)
-	
+
 	// Initialize parallel processor
 	processorConfig := &gopool.ProcessorConfig{
 		MaxWorkers:        parallelConfig.MaxGoroutines,
@@ -100,19 +100,19 @@ func NewParallelStateProcessor(config *params.ChainConfig, bc *BlockChain, engin
 		ConsensusWorkers:  runtime.NumCPU() / 2,
 		NetworkWorkers:    runtime.NumCPU(),
 	}
-	
+
 	processor, err := gopool.NewParallelProcessor(processorConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create parallel processor: %w", err)
 	}
-	
+
 	psp := &ParallelStateProcessor{
 		StateProcessor: baseProcessor,
 		processor:      processor,
 		config:         parallelConfig,
 		maxConcurrency: int32(parallelConfig.MaxTxConcurrency),
 	}
-	
+
 	log.Info("Parallel state processor initialized",
 		"maxTxConcurrency", parallelConfig.MaxTxConcurrency,
 		"txBatchSize", parallelConfig.TxBatchSize,
@@ -121,7 +121,7 @@ func NewParallelStateProcessor(config *params.ChainConfig, bc *BlockChain, engin
 		"pipelining", parallelConfig.EnablePipelining,
 		"batching", parallelConfig.EnableTxBatching,
 	)
-	
+
 	return psp, nil
 }
 
@@ -138,7 +138,7 @@ func (psp *ParallelStateProcessor) ProcessParallel(block *types.Block, statedb *
 			"tps", float64(len(block.Transactions()))/duration.Seconds(),
 		)
 	}()
-	
+
 	var (
 		receipts    = make([]*types.Receipt, 0, len(block.Transactions()))
 		usedGas     = new(uint64)
@@ -148,11 +148,11 @@ func (psp *ParallelStateProcessor) ProcessParallel(block *types.Block, statedb *
 		allLogs     []*types.Log
 		gp          = new(GasPool).AddGas(block.GasLimit())
 	)
-	
+
 	// Create EVM context
 	blockContext := NewEVMBlockContext(header, psp.bc, nil)
 	vmenv := vm.NewEVM(blockContext, vm.TxContext{}, statedb, psp.StateProcessor.config, cfg)
-	
+
 	// Handle PoSA consensus if applicable
 	posa, isPoSA := psp.engine.(consensus.PoSA)
 	if isPoSA {
@@ -161,17 +161,17 @@ func (psp *ParallelStateProcessor) ProcessParallel(block *types.Block, statedb *
 		}
 		vmenv.Context.ExtraValidator = posa.CreateEvmExtraValidator(header, statedb)
 	}
-	
+
 	// Preload accounts for better performance
 	signer := types.MakeSigner(psp.StateProcessor.config, header.Number)
 	statedb.PreloadAccounts(block, signer)
-	
+
 	// Separate system and regular transactions
 	commonTxs, systemTxs, err := psp.separateTransactions(block.Transactions(), signer, header, isPoSA, posa)
 	if err != nil {
 		return nil, nil, 0, err
 	}
-	
+
 	// Process transactions based on configuration
 	if psp.config.EnableTxBatching && len(commonTxs) > psp.config.TxBatchSize {
 		receipts, allLogs, err = psp.processBatchedTransactions(commonTxs, statedb, vmenv, gp, usedGas, blockNumber, blockHash)
@@ -180,16 +180,55 @@ func (psp *ParallelStateProcessor) ProcessParallel(block *types.Block, statedb *
 	} else {
 		receipts, allLogs, err = psp.processSequentialTransactions(commonTxs, statedb, vmenv, gp, usedGas, blockNumber, blockHash)
 	}
-	
+
 	if err != nil {
 		return nil, nil, 0, err
 	}
-	
+
 	// Finalize the block
 	if err := psp.engine.Finalize(psp.bc, header, statedb, &commonTxs, block.Uncles(), &receipts, systemTxs); err != nil {
 		return nil, nil, 0, err
 	}
-	
+
+	return receipts, allLogs, *usedGas, nil
+}
+
+// ApplyTransactions processes an arbitrary set of transactions against the
+// provided state using the parallel execution engine. It is primarily used for
+// GPU pre-validated batches during block construction.
+func (psp *ParallelStateProcessor) ApplyTransactions(header *types.Header, statedb *state.StateDB, gp *GasPool, initialGasUsed uint64, txs []*types.Transaction, cfg vm.Config, extraValidator types.EvmExtraValidator) (types.Receipts, []*types.Log, uint64, error) {
+	if len(txs) == 0 {
+		return nil, nil, initialGasUsed, nil
+	}
+
+	usedGas := new(uint64)
+	*usedGas = initialGasUsed
+
+	blockHash := header.Hash()
+	blockNumber := header.Number
+
+	blockContext := NewEVMBlockContext(header, psp.bc, &header.Coinbase)
+	blockContext.ExtraValidator = extraValidator
+	vmenv := vm.NewEVM(blockContext, vm.TxContext{}, statedb, psp.StateProcessor.config, cfg)
+
+	var (
+		receipts types.Receipts
+		allLogs  []*types.Log
+		err      error
+	)
+
+	if psp.config.EnableTxBatching && len(txs) > psp.config.TxBatchSize {
+		receipts, allLogs, err = psp.processBatchedTransactions(txs, statedb, vmenv, gp, usedGas, blockNumber, blockHash)
+	} else if psp.config.EnablePipelining {
+		receipts, allLogs, err = psp.processPipelinedTransactions(txs, statedb, vmenv, gp, usedGas, blockNumber, blockHash)
+	} else {
+		receipts, allLogs, err = psp.processSequentialTransactions(txs, statedb, vmenv, gp, usedGas, blockNumber, blockHash)
+	}
+
+	if err != nil {
+		return nil, nil, *usedGas, err
+	}
+
 	return receipts, allLogs, *usedGas, nil
 }
 
@@ -197,19 +236,19 @@ func (psp *ParallelStateProcessor) ProcessParallel(block *types.Block, statedb *
 func (psp *ParallelStateProcessor) separateTransactions(txs []*types.Transaction, signer types.Signer, header *types.Header, isPoSA bool, posa consensus.PoSA) ([]*types.Transaction, []*types.Transaction, error) {
 	commonTxs := make([]*types.Transaction, 0, len(txs))
 	systemTxs := make([]*types.Transaction, 0)
-	
+
 	for _, tx := range txs {
 		if isPoSA {
 			sender, err := types.Sender(signer, tx)
 			if err != nil {
 				return nil, nil, err
 			}
-			
+
 			ok, err := posa.IsSysTransaction(sender, tx, header)
 			if err != nil {
 				return nil, nil, err
 			}
-			
+
 			if ok {
 				systemTxs = append(systemTxs, tx)
 				continue
@@ -217,7 +256,7 @@ func (psp *ParallelStateProcessor) separateTransactions(txs []*types.Transaction
 		}
 		commonTxs = append(commonTxs, tx)
 	}
-	
+
 	return commonTxs, systemTxs, nil
 }
 
@@ -225,10 +264,10 @@ func (psp *ParallelStateProcessor) separateTransactions(txs []*types.Transaction
 func (psp *ParallelStateProcessor) processBatchedTransactions(txs []*types.Transaction, statedb *state.StateDB, vmenv *vm.EVM, gp *GasPool, usedGas *uint64, blockNumber *big.Int, blockHash common.Hash) ([]*types.Receipt, []*types.Log, error) {
 	receipts := make([]*types.Receipt, len(txs))
 	allLogs := make([]*types.Log, 0)
-	
+
 	batchSize := psp.config.TxBatchSize
 	numBatches := (len(txs) + batchSize - 1) / batchSize
-	
+
 	// Process batches sequentially to maintain state consistency
 	for batchIdx := 0; batchIdx < numBatches; batchIdx++ {
 		start := batchIdx * batchSize
@@ -236,18 +275,18 @@ func (psp *ParallelStateProcessor) processBatchedTransactions(txs []*types.Trans
 		if end > len(txs) {
 			end = len(txs)
 		}
-		
+
 		batchTxs := txs[start:end]
 		batchReceipts, batchLogs, err := psp.processBatch(batchTxs, start, statedb, vmenv, gp, usedGas, blockNumber, blockHash)
 		if err != nil {
 			return nil, nil, err
 		}
-		
+
 		// Copy results
 		copy(receipts[start:end], batchReceipts)
 		allLogs = append(allLogs, batchLogs...)
 	}
-	
+
 	return receipts, allLogs, nil
 }
 
@@ -255,31 +294,31 @@ func (psp *ParallelStateProcessor) processBatchedTransactions(txs []*types.Trans
 func (psp *ParallelStateProcessor) processBatch(txs []*types.Transaction, startIdx int, statedb *state.StateDB, vmenv *vm.EVM, gp *GasPool, usedGas *uint64, blockNumber *big.Int, blockHash common.Hash) ([]*types.Receipt, []*types.Log, error) {
 	receipts := make([]*types.Receipt, len(txs))
 	allLogs := make([]*types.Log, 0)
-	
+
 	var bloomWg sync.WaitGroup
-	
+
 	// Process transactions sequentially within batch (for state consistency)
 	for i, tx := range txs {
 		msg, err := tx.AsMessage(types.MakeSigner(psp.StateProcessor.config, blockNumber), nil)
 		if err != nil {
 			return nil, nil, fmt.Errorf("could not apply tx %d [%v]: %w", startIdx+i, tx.Hash().Hex(), err)
 		}
-		
+
 		statedb.Prepare(tx.Hash(), startIdx+i)
-		
+
 		// Apply transaction
 		receipt, err := psp.applyTransactionParallel(msg, psp.StateProcessor.config, psp.bc, nil, gp, statedb, blockNumber, blockHash, tx, usedGas, vmenv, &bloomWg)
 		if err != nil {
 			return nil, nil, fmt.Errorf("could not apply tx %d [%v]: %w", startIdx+i, tx.Hash().Hex(), err)
 		}
-		
+
 		receipts[i] = receipt
 		allLogs = append(allLogs, receipt.Logs...)
 	}
-	
+
 	// Wait for all bloom filters to be created
 	bloomWg.Wait()
-	
+
 	return receipts, allLogs, nil
 }
 
@@ -287,15 +326,15 @@ func (psp *ParallelStateProcessor) processBatch(txs []*types.Transaction, startI
 func (psp *ParallelStateProcessor) processPipelinedTransactions(txs []*types.Transaction, statedb *state.StateDB, vmenv *vm.EVM, gp *GasPool, usedGas *uint64, blockNumber *big.Int, blockHash common.Hash) ([]*types.Receipt, []*types.Log, error) {
 	receipts := make([]*types.Receipt, len(txs))
 	allLogs := make([]*types.Log, 0)
-	
+
 	// Pipeline stages: validation -> execution -> bloom creation
 	validationCh := make(chan *txValidationResult, psp.config.MaxTxConcurrency)
 	executionCh := make(chan *txExecutionResult, psp.config.MaxTxConcurrency)
-	
+
 	var wg sync.WaitGroup
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	
+
 	// Stage 1: Transaction validation
 	wg.Add(1)
 	go func() {
@@ -303,7 +342,7 @@ func (psp *ParallelStateProcessor) processPipelinedTransactions(txs []*types.Tra
 		defer close(validationCh)
 		psp.validateTransactionsPipeline(ctx, txs, blockNumber, validationCh)
 	}()
-	
+
 	// Stage 2: Transaction execution
 	wg.Add(1)
 	go func() {
@@ -311,16 +350,16 @@ func (psp *ParallelStateProcessor) processPipelinedTransactions(txs []*types.Tra
 		defer close(executionCh)
 		psp.executeTransactionsPipeline(ctx, validationCh, statedb, vmenv, gp, usedGas, blockNumber, blockHash, executionCh)
 	}()
-	
+
 	// Stage 3: Result collection and bloom creation
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		psp.collectResultsPipeline(ctx, executionCh, receipts, &allLogs)
 	}()
-	
+
 	wg.Wait()
-	
+
 	return receipts, allLogs, nil
 }
 
@@ -328,26 +367,26 @@ func (psp *ParallelStateProcessor) processPipelinedTransactions(txs []*types.Tra
 func (psp *ParallelStateProcessor) processSequentialTransactions(txs []*types.Transaction, statedb *state.StateDB, vmenv *vm.EVM, gp *GasPool, usedGas *uint64, blockNumber *big.Int, blockHash common.Hash) ([]*types.Receipt, []*types.Log, error) {
 	receipts := make([]*types.Receipt, len(txs))
 	allLogs := make([]*types.Log, 0)
-	
+
 	var bloomWg sync.WaitGroup
-	
+
 	for i, tx := range txs {
 		msg, err := tx.AsMessage(types.MakeSigner(psp.StateProcessor.config, blockNumber), nil)
 		if err != nil {
 			return nil, nil, fmt.Errorf("could not apply tx %d [%v]: %w", i, tx.Hash().Hex(), err)
 		}
-		
+
 		statedb.Prepare(tx.Hash(), i)
-		
+
 		receipt, err := psp.applyTransactionParallel(msg, psp.StateProcessor.config, psp.bc, nil, gp, statedb, blockNumber, blockHash, tx, usedGas, vmenv, &bloomWg)
 		if err != nil {
 			return nil, nil, fmt.Errorf("could not apply tx %d [%v]: %w", i, tx.Hash().Hex(), err)
 		}
-		
+
 		receipts[i] = receipt
 		allLogs = append(allLogs, receipt.Logs...)
 	}
-	
+
 	bloomWg.Wait()
 	return receipts, allLogs, nil
 }
@@ -357,13 +396,13 @@ func (psp *ParallelStateProcessor) applyTransactionParallel(msg types.Message, c
 	// Create a new context to be used in the EVM environment
 	txContext := NewEVMTxContext(msg)
 	evm.Reset(txContext, statedb)
-	
+
 	// Apply the transaction to the current state
 	result, err := ApplyMessage(evm, msg, gp)
 	if err != nil {
 		return nil, err
 	}
-	
+
 	// Update the state with pending changes
 	var root []byte
 	if config.IsByzantium(blockNumber) {
@@ -372,7 +411,7 @@ func (psp *ParallelStateProcessor) applyTransactionParallel(msg types.Message, c
 		root = statedb.IntermediateRoot(config.IsEIP158(blockNumber)).Bytes()
 	}
 	*usedGas += result.UsedGas
-	
+
 	// Create receipt
 	receipt := &types.Receipt{Type: tx.Type(), PostState: root, CumulativeGasUsed: *usedGas}
 	if result.Failed() {
@@ -382,18 +421,18 @@ func (psp *ParallelStateProcessor) applyTransactionParallel(msg types.Message, c
 	}
 	receipt.TxHash = tx.Hash()
 	receipt.GasUsed = result.UsedGas
-	
+
 	// Set contract address if contract creation
 	if msg.To() == nil {
 		receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, tx.Nonce())
 	}
-	
+
 	// Set logs and create bloom filter
 	receipt.Logs = statedb.GetLogs(tx.Hash(), blockHash)
 	receipt.BlockHash = blockHash
 	receipt.BlockNumber = blockNumber
 	receipt.TransactionIndex = uint(statedb.TxIndex())
-	
+
 	// Create bloom filter in parallel if enabled
 	if psp.config.EnableBloomParallel && bloomWg != nil {
 		bloomWg.Add(1)
@@ -413,7 +452,7 @@ func (psp *ParallelStateProcessor) applyTransactionParallel(msg types.Message, c
 	} else {
 		receipt.Bloom = types.CreateBloom(types.Receipts{receipt})
 	}
-	
+
 	return receipt, nil
 }
 
@@ -434,14 +473,14 @@ type txExecutionResult struct {
 
 func (psp *ParallelStateProcessor) validateTransactionsPipeline(ctx context.Context, txs []*types.Transaction, blockNumber *big.Int, output chan<- *txValidationResult) {
 	signer := types.MakeSigner(psp.StateProcessor.config, blockNumber)
-	
+
 	for i, tx := range txs {
 		select {
 		case <-ctx.Done():
 			return
 		default:
 		}
-		
+
 		msg, err := tx.AsMessage(signer, nil)
 		result := &txValidationResult{
 			index: i,
@@ -449,7 +488,7 @@ func (psp *ParallelStateProcessor) validateTransactionsPipeline(ctx context.Cont
 			msg:   msg,
 			err:   err,
 		}
-		
+
 		select {
 		case output <- result:
 		case <-ctx.Done():
@@ -467,7 +506,7 @@ func (psp *ParallelStateProcessor) executeTransactionsPipeline(ctx context.Conte
 			if !ok {
 				return
 			}
-			
+
 			if validation.err != nil {
 				result := &txExecutionResult{
 					index: validation.index,
@@ -480,21 +519,21 @@ func (psp *ParallelStateProcessor) executeTransactionsPipeline(ctx context.Conte
 				}
 				continue
 			}
-			
+
 			statedb.Prepare(validation.tx.Hash(), validation.index)
-			
+
 			receipt, err := psp.applyTransactionParallel(validation.msg, psp.StateProcessor.config, psp.bc, nil, gp, statedb, blockNumber, blockHash, validation.tx, usedGas, vmenv, nil)
-			
+
 			result := &txExecutionResult{
 				index:   validation.index,
 				receipt: receipt,
 				err:     err,
 			}
-			
+
 			if receipt != nil {
 				result.logs = receipt.Logs
 			}
-			
+
 			select {
 			case output <- result:
 			case <-ctx.Done():
@@ -513,12 +552,12 @@ func (psp *ParallelStateProcessor) collectResultsPipeline(ctx context.Context, i
 			if !ok {
 				return
 			}
-			
+
 			if result.err != nil {
 				log.Error("Transaction execution failed", "index", result.index, "err", result.err)
 				continue
 			}
-			
+
 			receipts[result.index] = result.receipt
 			*allLogs = append(*allLogs, result.logs...)
 		}
@@ -529,14 +568,14 @@ func (psp *ParallelStateProcessor) collectResultsPipeline(ctx context.Context, i
 func (psp *ParallelStateProcessor) updateMetrics(duration time.Duration) {
 	psp.mu.Lock()
 	defer psp.mu.Unlock()
-	
+
 	psp.processedBlocks++
 	if psp.avgBlockTime == 0 {
 		psp.avgBlockTime = duration
 	} else {
 		psp.avgBlockTime = (psp.avgBlockTime + duration) / 2
 	}
-	
+
 	// Adaptive scaling based on performance
 	if psp.config.AdaptiveScaling {
 		psp.adjustConcurrency(duration)
@@ -545,14 +584,14 @@ func (psp *ParallelStateProcessor) updateMetrics(duration time.Duration) {
 
 func (psp *ParallelStateProcessor) adjustConcurrency(duration time.Duration) {
 	currentConcurrency := atomic.LoadInt32(&psp.maxConcurrency)
-	
+
 	// If processing is too slow, reduce concurrency to avoid overhead
 	if duration > 5*time.Second && currentConcurrency > 1 {
 		newConcurrency := currentConcurrency * 8 / 10 // Reduce by 20%
 		atomic.StoreInt32(&psp.maxConcurrency, newConcurrency)
 		log.Debug("Reduced concurrency due to slow processing", "old", currentConcurrency, "new", newConcurrency)
 	}
-	
+
 	// If processing is fast and we have capacity, increase concurrency
 	if duration < 1*time.Second && currentConcurrency < int32(psp.config.MaxTxConcurrency) {
 		newConcurrency := currentConcurrency * 11 / 10 // Increase by 10%
@@ -568,22 +607,22 @@ func (psp *ParallelStateProcessor) adjustConcurrency(duration time.Duration) {
 func (psp *ParallelStateProcessor) GetStats() ParallelProcessorStats {
 	psp.mu.RLock()
 	defer psp.mu.RUnlock()
-	
+
 	processorStats := psp.processor.GetStats()
-	
+
 	return ParallelProcessorStats{
-		ProcessedBlocks:   psp.processedBlocks,
-		AvgBlockTime:      psp.avgBlockTime,
+		ProcessedBlocks:    psp.processedBlocks,
+		AvgBlockTime:       psp.avgBlockTime,
 		CurrentConcurrency: atomic.LoadInt32(&psp.maxConcurrency),
-		ProcessorStats:    processorStats,
+		ProcessorStats:     processorStats,
 	}
 }
 
 type ParallelProcessorStats struct {
-	ProcessedBlocks     uint64                  `json:"processedBlocks"`
-	AvgBlockTime        time.Duration           `json:"avgBlockTime"`
-	CurrentConcurrency  int32                   `json:"currentConcurrency"`
-	ProcessorStats      gopool.ProcessorStats   `json:"processorStats"`
+	ProcessedBlocks    uint64                `json:"processedBlocks"`
+	AvgBlockTime       time.Duration         `json:"avgBlockTime"`
+	CurrentConcurrency int32                 `json:"currentConcurrency"`
+	ProcessorStats     gopool.ProcessorStats `json:"processorStats"`
 }
 
 // Close shuts down the parallel processor


### PR DESCRIPTION
## Summary
- route GPU-validated transaction batches through a new `applyValidatedTransactionsParallel` helper that leverages the parallel state processor and records executor diagnostics
- ensure GPU batches signal completion via a wait group, keeping block assembly in sync while logging main-thread dispatch versus executor runtimes
- expose `ParallelStateProcessor.ApplyTransactions` so GPU batches can reuse the parallel execution pipeline without forcing full block finalisation

## Testing
- go test ./core/... ./miner/... *(fails: missing OpenCL headers and numerous upstream blockchain/forkid expectations in the existing tree)*


------
https://chatgpt.com/codex/tasks/task_e_68cc2647221c83249525d1afe2498cee