### PR TITLE
Refine hybrid logging configuration for high TPS stability

### DIFF
--- a/Core-Blockchain/node-setup.sh
+++ b/Core-Blockchain/node-setup.sh
@@ -406,11 +406,6 @@ ENABLE_GPU=true
 PREFERRED_GPU_TYPE=CUDA
 GPU_MAX_BATCH_SIZE=800000
 GPU_MAX_MEMORY_USAGE=19327352832
->>>>>>> remotes/origin/codex/resolve-merge-conflicts-and-implement-plan
-GPU_MAX_MEMORY_USAGE=19327352832
-=======
-GPU_MAX_MEMORY_USAGE=19327352832
->>>>>>> remotes/origin/codex/resolve-merge-conflicts-and-implement-plan
 GPU_MEMORY_FRACTION=0.9
 GPU_HASH_WORKERS=80
 GPU_SIGNATURE_WORKERS=80
@@ -426,11 +421,14 @@ PERFORMANCE_MONITORING=true
 MAX_CPU_UTILIZATION=0.95
 MAX_GPU_UTILIZATION=0.98
 THROUGHPUT_TARGET=2000000
->>>>>>> remotes/origin/codex/resolve-merge-conflicts-and-implement-plan
-THROUGHPUT_TARGET=2000000
-=======
-THROUGHPUT_TARGET=2000000
->>>>>>> remotes/origin/codex/resolve-merge-conflicts-and-implement-plan
+
+# Logging controls for hybrid processing stability
+HYBRID_DEBUG_LOGS=true
+HYBRID_STRATEGY_LOG_COOLDOWN=10s
+HYBRID_METRICS_LOG_INTERVAL=1s
+HYBRID_THROUGHPUT_WARNING_COOLDOWN=5s
+HYBRID_THROUGHPUT_SUCCESS_COOLDOWN=30s
+HYBRID_BATCH_LOG_INTERVAL=2s
 
 # Memory Management (RTX 4000 SFF Ada - 20GB Total)
 MAX_MEMORY_USAGE=68719476736

--- a/Core-Blockchain/node_src/cmd/geth/main.go
+++ b/Core-Blockchain/node_src/cmd/geth/main.go
@@ -516,23 +516,18 @@ func initializeGPUAcceleration(ctx *cli.Context) {
 			PreferredGPUType: gpuType,
 			MaxBatchSize:     getEnvInt("GPU_MAX_BATCH_SIZE", 800000),
 			MaxMemoryUsage:   getEnvUint64("GPU_MAX_MEMORY_USAGE", 19327352832), // 18GB blockchain allocation
->>>>>>> remotes/origin/codex/resolve-merge-conflicts-and-implement-plan
-		ThroughputTarget:      getEnvUint64("THROUGHPUT_TARGET", 2000000),
-		GPUConfig: &gpu.GPUConfig{
-			PreferredGPUType: gpuType,
-			MaxBatchSize:     getEnvInt("GPU_MAX_BATCH_SIZE", 800000),
-			MaxMemoryUsage:   getEnvUint64("GPU_MAX_MEMORY_USAGE", 19327352832), // 18GB blockchain allocation
-=======
-		ThroughputTarget:      getEnvUint64("THROUGHPUT_TARGET", 2000000),
-		GPUConfig: &gpu.GPUConfig{
-			PreferredGPUType: gpuType,
-			MaxBatchSize:     getEnvInt("GPU_MAX_BATCH_SIZE", 800000),
-			MaxMemoryUsage:   getEnvUint64("GPU_MAX_MEMORY_USAGE", 19327352832), // 18GB blockchain allocation
->>>>>>> remotes/origin/codex/resolve-merge-conflicts-and-implement-plan
 			HashWorkers:      getEnvInt("GPU_HASH_WORKERS", 80),
 			SignatureWorkers: getEnvInt("GPU_SIGNATURE_WORKERS", 80),
 			TxWorkers:        getEnvInt("GPU_TX_WORKERS", 80),
 			EnablePipelining: getEnvBool("GPU_ENABLE_PIPELINING", true),
+		},
+		Logging: &hybrid.LoggingConfig{
+			EnableDebug:           getEnvBool("HYBRID_DEBUG_LOGS", true),
+			StrategyCooldown:      getEnvDurationSeconds("HYBRID_STRATEGY_LOG_COOLDOWN", 10*time.Second),
+			MetricsSampleInterval: getEnvDurationMS("HYBRID_METRICS_LOG_INTERVAL", time.Second),
+			WarningCooldown:       getEnvDurationSeconds("HYBRID_THROUGHPUT_WARNING_COOLDOWN", 5*time.Second),
+			SuccessCooldown:       getEnvDurationSeconds("HYBRID_THROUGHPUT_SUCCESS_COOLDOWN", 30*time.Second),
+			BatchLogInterval:      getEnvDurationSeconds("HYBRID_BATCH_LOG_INTERVAL", 2*time.Second),
 		},
 	}
 

--- a/Core-Blockchain/scripts/health-check.sh
+++ b/Core-Blockchain/scripts/health-check.sh
@@ -110,13 +110,8 @@ check_item "500B gas limit in env" "grep 'GAS_LIMIT=500000000000' ./.env"
 check_item "RTX 4000 batch size (800K)" "grep 'GPU_MAX_BATCH_SIZE=800000' ./.env"
 check_item "RTX 4000 memory (18GB blockchain allocation)" "grep 'GPU_MAX_MEMORY_USAGE=19327352832' ./.env"
 check_item "2M TPS target" "grep 'THROUGHPUT_TARGET=2000000' ./.env"
->>>>>>> remotes/origin/codex/resolve-merge-conflicts-and-implement-plan
-check_item "RTX 4000 memory (18GB blockchain allocation)" "grep 'GPU_MAX_MEMORY_USAGE=19327352832' ./.env"
-check_item "2M TPS target" "grep 'THROUGHPUT_TARGET=2000000' ./.env"
-=======
-check_item "RTX 4000 memory (18GB blockchain allocation)" "grep 'GPU_MAX_MEMORY_USAGE=19327352832' ./.env"
-check_item "2M TPS target" "grep 'THROUGHPUT_TARGET=2000000' ./.env"
->>>>>>> remotes/origin/codex/resolve-merge-conflicts-and-implement-plan
+check_warning "Hybrid logging cooldown configured" "grep 'HYBRID_STRATEGY_LOG_COOLDOWN' ./.env"
+check_warning "Hybrid metrics interval configured" "grep 'HYBRID_METRICS_LOG_INTERVAL' ./.env"
 
 echo -e "\n${PURPLE}=== 4. GPU ACCELERATION ===${NC}"
 


### PR DESCRIPTION
## Summary
- add a dedicated logging configuration for the hybrid processor and rate limit verbose emissions to keep the pipeline stable at very high TPS
- expose the new logging knobs through `geth` environment configuration and seed default values in the GPU setup helper
- extend the health check to verify the new logging settings are present

## Testing
- `go test ./...`
- `go test ./common/hybrid`


------
https://chatgpt.com/codex/tasks/task_e_68cc3fb7e2548324bf6b789124640f27