### PR TITLE
Improve GPU logging and status visibility

### DIFF
--- a/Core-Blockchain/node_src/common/gpu/gpu_processor.go
+++ b/Core-Blockchain/node_src/common/gpu/gpu_processor.go
@@ -48,12 +48,12 @@ int verifySignaturesOpenCL(void* signatures, int count, void* results);
 void cleanupOpenCL();
 
 // Working stub implementations for CUDA (can be replaced when CUDA is properly configured)
-int initCUDA() { 
+int initCUDA() {
     // Return -1 to indicate CUDA not available, system will fall back to OpenCL or CPU
-    return -1; 
+    return -1;
 }
 
-int processHashesCUDA(void* hashes, int count, void* results) { 
+int processHashesCUDA(void* hashes, int count, void* results) {
     return -1; // Not implemented, will fall back to OpenCL or CPU
 }
 
@@ -61,11 +61,11 @@ int verifySignaturesCUDA(void* signatures, int count, void* results) {
     return -1; // Not implemented, will fall back to OpenCL or CPU
 }
 
-int processTxBatchCUDA(void* txData, int txCount, void* results) { 
+int processTxBatchCUDA(void* txData, int txCount, void* results) {
     return -1; // Not implemented, will fall back to OpenCL or CPU
 }
 
-void cleanupCUDA() { 
+void cleanupCUDA() {
     // No-op for stub implementation
 }
 */
@@ -80,18 +80,30 @@ const (
 	GPUTypeOpenCL
 )
 
+// String returns a human-readable representation of the GPU type.
+func (t GPUType) String() string {
+	switch t {
+	case GPUTypeCUDA:
+		return "cuda"
+	case GPUTypeOpenCL:
+		return "opencl"
+	default:
+		return "none"
+	}
+}
+
 // GPUProcessor provides GPU-accelerated blockchain operations
 type GPUProcessor struct {
-	gpuType         GPUType
-	deviceCount     int
-	maxBatchSize    int
-	maxMemoryUsage  uint64
-	
+	gpuType        GPUType
+	deviceCount    int
+	maxBatchSize   int
+	maxMemoryUsage uint64
+
 	// Processing pools
-	hashPool        chan *HashBatch
-	signaturePool   chan *SignatureBatch
-	txPool          chan *TransactionBatch
-	
+	hashPool      chan *HashBatch
+	signaturePool chan *SignatureBatch
+	txPool        chan *TransactionBatch
+
 	// Statistics
 	mu              sync.RWMutex
 	processedHashes uint64
@@ -99,60 +111,60 @@ type GPUProcessor struct {
 	processedTxs    uint64
 	avgHashTime     time.Duration
 	avgSigTime      time.Duration
-    avgTxTime       time.Duration
-	
-    // Shutdown coordination
-	ctx             context.Context
-	cancel          context.CancelFunc
-	wg              sync.WaitGroup
-	
-    // Memory management
-    memoryPool      sync.Pool
-    cudaStreams     []unsafe.Pointer
-    openclQueues    []unsafe.Pointer
+	avgTxTime       time.Duration
 
-    // Scheduling state
-    enablePerSender bool
-    targetKernelMs  int
-    nextSliceSize   int
-    minSliceSize    int
-    maxSliceSize    int
+	// Shutdown coordination
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	// Memory management
+	memoryPool   sync.Pool
+	cudaStreams  []unsafe.Pointer
+	openclQueues []unsafe.Pointer
+
+	// Scheduling state
+	enablePerSender bool
+	targetKernelMs  int
+	nextSliceSize   int
+	minSliceSize    int
+	maxSliceSize    int
 }
 
 // GPUConfig holds configuration for GPU processing
 type GPUConfig struct {
-    PreferredGPUType GPUType `json:"preferredGpuType"`
-    MaxBatchSize     int     `json:"maxBatchSize"`
-    MaxMemoryUsage   uint64  `json:"maxMemoryUsage"`
-    HashWorkers      int     `json:"hashWorkers"`
-    SignatureWorkers int     `json:"signatureWorkers"`
-    TxWorkers        int     `json:"txWorkers"`
-    EnablePipelining bool    `json:"enablePipelining"`
-    // Scheduling and slicing
-    EnablePerSenderScheduling bool `json:"enablePerSenderScheduling"`
-    TargetKernelMillis        int  `json:"targetKernelMillis"`
-    InitialSliceSize          int  `json:"initialSliceSize"`
-    MinSliceSize              int  `json:"minSliceSize"`
-    MaxSliceSize              int  `json:"maxSliceSize"`
+	PreferredGPUType GPUType `json:"preferredGpuType"`
+	MaxBatchSize     int     `json:"maxBatchSize"`
+	MaxMemoryUsage   uint64  `json:"maxMemoryUsage"`
+	HashWorkers      int     `json:"hashWorkers"`
+	SignatureWorkers int     `json:"signatureWorkers"`
+	TxWorkers        int     `json:"txWorkers"`
+	EnablePipelining bool    `json:"enablePipelining"`
+	// Scheduling and slicing
+	EnablePerSenderScheduling bool `json:"enablePerSenderScheduling"`
+	TargetKernelMillis        int  `json:"targetKernelMillis"`
+	InitialSliceSize          int  `json:"initialSliceSize"`
+	MinSliceSize              int  `json:"minSliceSize"`
+	MaxSliceSize              int  `json:"maxSliceSize"`
 }
 
 // DefaultGPUConfig returns optimized GPU configuration for NVIDIA RTX 4000 SFF Ada (20GB VRAM)
 // Balanced for blockchain processing (optional vLLM with MobileLLM-R1-950M)
 func DefaultGPUConfig() *GPUConfig {
-    return &GPUConfig{
-        PreferredGPUType: GPUTypeCUDA,   // Prefer CUDA for RTX 4000 SFF Ada when available
-        MaxBatchSize:     800000,        // 4x increase - 800K batches (keeps GPU saturated)
-        MaxMemoryUsage:   18 * 1024 * 1024 * 1024, // 18GB GPU memory (reserve 2GB if running vLLM)
-        HashWorkers:      80,            // 80 workers - balance with AI workload
-        SignatureWorkers: 80,            // 80 workers - balance with AI workload
-        TxWorkers:        80,            // 80 workers - balance with AI workload
-        EnablePipelining: true,
-        EnablePerSenderScheduling: true,
-        TargetKernelMillis:        50,
-        InitialSliceSize:          65536,
-        MinSliceSize:              4096,
-        MaxSliceSize:              131072,
-    }
+	return &GPUConfig{
+		PreferredGPUType:          GPUTypeCUDA,             // Prefer CUDA for RTX 4000 SFF Ada when available
+		MaxBatchSize:              800000,                  // 4x increase - 800K batches (keeps GPU saturated)
+		MaxMemoryUsage:            18 * 1024 * 1024 * 1024, // 18GB GPU memory (reserve 2GB if running vLLM)
+		HashWorkers:               80,                      // 80 workers - balance with AI workload
+		SignatureWorkers:          80,                      // 80 workers - balance with AI workload
+		TxWorkers:                 80,                      // 80 workers - balance with AI workload
+		EnablePipelining:          true,
+		EnablePerSenderScheduling: true,
+		TargetKernelMillis:        50,
+		InitialSliceSize:          65536,
+		MinSliceSize:              4096,
+		MaxSliceSize:              131072,
+	}
 }
 
 // HashBatch represents a batch of hashes to process
@@ -190,13 +202,13 @@ type TxResult struct {
 // NewGPUProcessor creates a new GPU processor
 func NewGPUProcessor(config *GPUConfig) (*GPUProcessor, error) {
 	log.Info("Initializing GPU processor", "config", config)
-	
+
 	if config == nil {
 		log.Debug("No config provided, using default GPU configuration")
 		config = DefaultGPUConfig()
 	}
-	
-	log.Debug("GPU processor configuration", 
+
+	log.Debug("GPU processor configuration",
 		"preferredGPUType", config.PreferredGPUType,
 		"maxBatchSize", config.MaxBatchSize,
 		"maxMemoryUsage", config.MaxMemoryUsage,
@@ -205,30 +217,30 @@ func NewGPUProcessor(config *GPUConfig) (*GPUProcessor, error) {
 		"txWorkers", config.TxWorkers,
 		"enablePipelining", config.EnablePipelining,
 	)
-	
+
 	ctx, cancel := context.WithCancel(context.Background())
-	
-    processor := &GPUProcessor{
-        maxBatchSize:   config.MaxBatchSize,
-        maxMemoryUsage: config.MaxMemoryUsage,
-        ctx:            ctx,
-        cancel:         cancel,
-        hashPool:       make(chan *HashBatch, 100),
-        signaturePool:  make(chan *SignatureBatch, 100),
-        txPool:         make(chan *TransactionBatch, 100),
-        enablePerSender: config.EnablePerSenderScheduling,
-        targetKernelMs:  config.TargetKernelMillis,
-        nextSliceSize:   config.InitialSliceSize,
-        minSliceSize:    config.MinSliceSize,
-        maxSliceSize:    config.MaxSliceSize,
-    }
-	
-	log.Debug("Created GPU processor channels", 
+
+	processor := &GPUProcessor{
+		maxBatchSize:    config.MaxBatchSize,
+		maxMemoryUsage:  config.MaxMemoryUsage,
+		ctx:             ctx,
+		cancel:          cancel,
+		hashPool:        make(chan *HashBatch, 100),
+		signaturePool:   make(chan *SignatureBatch, 100),
+		txPool:          make(chan *TransactionBatch, 100),
+		enablePerSender: config.EnablePerSenderScheduling,
+		targetKernelMs:  config.TargetKernelMillis,
+		nextSliceSize:   config.InitialSliceSize,
+		minSliceSize:    config.MinSliceSize,
+		maxSliceSize:    config.MaxSliceSize,
+	}
+
+	log.Debug("Created GPU processor channels",
 		"hashPoolSize", cap(processor.hashPool),
 		"signaturePoolSize", cap(processor.signaturePool),
 		"txPoolSize", cap(processor.txPool),
 	)
-	
+
 	// Initialize memory pool
 	memoryPoolSize := config.MaxBatchSize * 256
 	log.Debug("Initializing memory pool", "itemSize", memoryPoolSize)
@@ -238,56 +250,56 @@ func NewGPUProcessor(config *GPUConfig) (*GPUProcessor, error) {
 			return make([]byte, memoryPoolSize) // 256 bytes per item
 		},
 	}
-	
+
 	// Try to initialize GPU
 	log.Info("Attempting GPU initialization", "preferredType", config.PreferredGPUType)
 	if err := processor.initializeGPU(config.PreferredGPUType); err != nil {
 		log.Warn("GPU initialization failed, falling back to CPU", "error", err)
 		processor.gpuType = GPUTypeNone
 	}
-	
+
 	// Start worker goroutines
 	log.Info("Starting GPU worker goroutines")
 	processor.startWorkers(config)
-	
-	log.Info("GPU processor initialized successfully", 
+
+	log.Info("GPU processor initialized successfully",
 		"type", processor.gpuType,
 		"deviceCount", processor.deviceCount,
 		"maxBatchSize", processor.maxBatchSize,
 		"maxMemoryUsage", processor.maxMemoryUsage,
 	)
-	
+
 	return processor, nil
 }
 
 // initializeGPU attempts to initialize GPU acceleration
 func (p *GPUProcessor) initializeGPU(preferredType GPUType) error {
 	log.Debug("Starting GPU initialization process", "preferredType", preferredType)
-	
+
 	// Try CUDA first if preferred or if no preference
 	if preferredType == GPUTypeCUDA || preferredType == GPUTypeNone {
 		log.Debug("Attempting CUDA initialization")
 		start := time.Now()
 		result := C.cuda_init_device()
 		initDuration := time.Since(start)
-		
-		log.Debug("CUDA initialization attempt completed", 
-			"result", int(result), 
+
+		log.Debug("CUDA initialization attempt completed",
+			"result", int(result),
 			"duration", initDuration,
 			"success", result > 0,
 		)
-		
+
 		if result > 0 {
 			p.gpuType = GPUTypeCUDA
 			p.deviceCount = int(result)
-			log.Info("CUDA GPU acceleration enabled successfully", 
+			log.Info("CUDA GPU acceleration enabled successfully",
 				"devices", p.deviceCount,
 				"initDuration", initDuration,
 				"gpuType", "CUDA",
 			)
 			return nil
 		} else {
-			log.Warn("CUDA initialization failed", 
+			log.Warn("CUDA initialization failed",
 				"result", int(result),
 				"duration", initDuration,
 				"reason", "cuda_init_device returned non-positive value",
@@ -296,24 +308,24 @@ func (p *GPUProcessor) initializeGPU(preferredType GPUType) error {
 	} else {
 		log.Debug("Skipping CUDA initialization", "reason", "not preferred type")
 	}
-	
+
 	// Try OpenCL if CUDA failed or if preferred
 	if preferredType == GPUTypeOpenCL || preferredType == GPUTypeNone {
 		log.Debug("Attempting OpenCL initialization")
 		start := time.Now()
 		result := C.initOpenCL()
 		initDuration := time.Since(start)
-		
-		log.Debug("OpenCL initialization attempt completed", 
-			"result", int(result), 
+
+		log.Debug("OpenCL initialization attempt completed",
+			"result", int(result),
 			"duration", initDuration,
 			"success", result > 0,
 		)
-		
+
 		if result > 0 {
 			p.gpuType = GPUTypeOpenCL
 			p.deviceCount = int(result)
-			log.Info("OpenCL GPU acceleration enabled successfully", 
+			log.Info("OpenCL GPU acceleration enabled successfully",
 				"devices", p.deviceCount,
 				"initDuration", initDuration,
 				"gpuType", "OpenCL",
@@ -321,7 +333,7 @@ func (p *GPUProcessor) initializeGPU(preferredType GPUType) error {
 			)
 			return nil
 		} else {
-			log.Warn("OpenCL initialization failed", 
+			log.Warn("OpenCL initialization failed",
 				"result", int(result),
 				"duration", initDuration,
 				"reason", "initOpenCL returned non-positive value",
@@ -330,13 +342,13 @@ func (p *GPUProcessor) initializeGPU(preferredType GPUType) error {
 	} else {
 		log.Debug("Skipping OpenCL initialization", "reason", "not preferred type")
 	}
-	
-	log.Error("All GPU initialization attempts failed", 
+
+	log.Error("All GPU initialization attempts failed",
 		"preferredType", preferredType,
 		"cudaAttempted", preferredType == GPUTypeCUDA || preferredType == GPUTypeNone,
 		"openclAttempted", preferredType == GPUTypeOpenCL || preferredType == GPUTypeNone,
 	)
-	
+
 	return errors.New("no GPU acceleration available")
 }
 
@@ -347,13 +359,13 @@ func (p *GPUProcessor) startWorkers(config *GPUConfig) {
 		p.wg.Add(1)
 		go p.hashWorker()
 	}
-	
+
 	// Signature verification workers
 	for i := 0; i < config.SignatureWorkers; i++ {
 		p.wg.Add(1)
 		go p.signatureWorker()
 	}
-	
+
 	// Transaction processing workers
 	for i := 0; i < config.TxWorkers; i++ {
 		p.wg.Add(1)
@@ -364,40 +376,40 @@ func (p *GPUProcessor) startWorkers(config *GPUConfig) {
 // ProcessHashesBatch processes a batch of hashes using GPU acceleration
 func (p *GPUProcessor) ProcessHashesBatch(hashes [][]byte, callback func([][]byte, error)) error {
 	log.Trace("ProcessHashesBatch called", "batchSize", len(hashes))
-	
+
 	if len(hashes) == 0 {
 		log.Debug("Empty hash batch received, calling callback with nil")
 		callback(nil, nil)
 		return nil
 	}
-	
+
 	// Validate input parameters
 	if callback == nil {
 		log.Error("ProcessHashesBatch called with nil callback")
 		return errors.New("callback cannot be nil")
 	}
-	
+
 	// Check batch size limits
 	if len(hashes) > p.maxBatchSize {
-		log.Warn("Hash batch size exceeds maximum", 
+		log.Warn("Hash batch size exceeds maximum",
 			"batchSize", len(hashes),
 			"maxBatchSize", p.maxBatchSize,
 		)
 		return errors.New("batch size exceeds maximum allowed")
 	}
-	
+
 	batch := &HashBatch{
 		Hashes:   hashes,
 		Results:  make([][]byte, len(hashes)),
 		Callback: callback,
 	}
-	
-	log.Debug("Submitting hash batch for processing", 
+
+	log.Debug("Submitting hash batch for processing",
 		"batchSize", len(hashes),
 		"queueSize", len(p.hashPool),
 		"queueCapacity", cap(p.hashPool),
 	)
-	
+
 	select {
 	case p.hashPool <- batch:
 		log.Trace("Hash batch successfully queued for processing")
@@ -406,7 +418,7 @@ func (p *GPUProcessor) ProcessHashesBatch(hashes [][]byte, callback func([][]byt
 		log.Debug("Hash batch submission cancelled due to context cancellation")
 		return p.ctx.Err()
 	default:
-		log.Error("Hash processing queue full, rejecting batch", 
+		log.Error("Hash processing queue full, rejecting batch",
 			"batchSize", len(hashes),
 			"queueSize", len(p.hashPool),
 			"queueCapacity", cap(p.hashPool),
@@ -418,38 +430,38 @@ func (p *GPUProcessor) ProcessHashesBatch(hashes [][]byte, callback func([][]byt
 // ProcessSignaturesBatch verifies a batch of signatures using GPU acceleration
 func (p *GPUProcessor) ProcessSignaturesBatch(signatures, messages, publicKeys [][]byte, callback func([]bool, error)) error {
 	log.Trace("ProcessSignaturesBatch called", "batchSize", len(signatures))
-	
+
 	if len(signatures) == 0 {
 		log.Debug("Empty signature batch received, calling callback with nil")
 		callback(nil, nil)
 		return nil
 	}
-	
+
 	// Validate input parameters
 	if callback == nil {
 		log.Error("ProcessSignaturesBatch called with nil callback")
 		return errors.New("callback cannot be nil")
 	}
-	
+
 	// Validate batch consistency
 	if len(signatures) != len(messages) || len(signatures) != len(publicKeys) {
-		log.Error("Signature batch arrays have mismatched lengths", 
+		log.Error("Signature batch arrays have mismatched lengths",
 			"signaturesLen", len(signatures),
 			"messagesLen", len(messages),
 			"publicKeysLen", len(publicKeys),
 		)
 		return errors.New("signature batch arrays must have equal lengths")
 	}
-	
+
 	// Check batch size limits
 	if len(signatures) > p.maxBatchSize {
-		log.Warn("Signature batch size exceeds maximum", 
+		log.Warn("Signature batch size exceeds maximum",
 			"batchSize", len(signatures),
 			"maxBatchSize", p.maxBatchSize,
 		)
 		return errors.New("batch size exceeds maximum allowed")
 	}
-	
+
 	batch := &SignatureBatch{
 		Signatures: signatures,
 		Messages:   messages,
@@ -457,13 +469,13 @@ func (p *GPUProcessor) ProcessSignaturesBatch(signatures, messages, publicKeys [
 		Results:    make([]bool, len(signatures)),
 		Callback:   callback,
 	}
-	
-	log.Debug("Submitting signature batch for processing", 
+
+	log.Debug("Submitting signature batch for processing",
 		"batchSize", len(signatures),
 		"queueSize", len(p.signaturePool),
 		"queueCapacity", cap(p.signaturePool),
 	)
-	
+
 	select {
 	case p.signaturePool <- batch:
 		log.Trace("Signature batch successfully queued for processing")
@@ -472,7 +484,7 @@ func (p *GPUProcessor) ProcessSignaturesBatch(signatures, messages, publicKeys [
 		log.Debug("Signature batch submission cancelled due to context cancellation")
 		return p.ctx.Err()
 	default:
-		log.Error("Signature processing queue full, rejecting batch", 
+		log.Error("Signature processing queue full, rejecting batch",
 			"batchSize", len(signatures),
 			"queueSize", len(p.signaturePool),
 			"queueCapacity", cap(p.signaturePool),
@@ -484,19 +496,19 @@ func (p *GPUProcessor) ProcessSignaturesBatch(signatures, messages, publicKeys [
 // ProcessTransactionsBatch processes a batch of transactions using GPU acceleration
 func (p *GPUProcessor) ProcessTransactionsBatch(txs []*types.Transaction, callback func([]*TxResult, error)) error {
 	log.Trace("ProcessTransactionsBatch called", "batchSize", len(txs))
-	
+
 	if len(txs) == 0 {
 		log.Debug("Empty transaction batch received, calling callback with nil")
 		callback(nil, nil)
 		return nil
 	}
-	
+
 	// Validate input parameters
 	if callback == nil {
 		log.Error("ProcessTransactionsBatch called with nil callback")
 		return errors.New("callback cannot be nil")
 	}
-	
+
 	// Validate transactions
 	nilTxCount := 0
 	for i, tx := range txs {
@@ -505,36 +517,36 @@ func (p *GPUProcessor) ProcessTransactionsBatch(txs []*types.Transaction, callba
 			log.Warn("Nil transaction found in batch", "index", i)
 		}
 	}
-	
+
 	if nilTxCount > 0 {
-		log.Error("Transaction batch contains nil transactions", 
+		log.Error("Transaction batch contains nil transactions",
 			"nilCount", nilTxCount,
 			"totalCount", len(txs),
 		)
 		return errors.New("batch contains nil transactions")
 	}
-	
+
 	// Check batch size limits
 	if len(txs) > p.maxBatchSize {
-		log.Warn("Transaction batch size exceeds maximum", 
+		log.Warn("Transaction batch size exceeds maximum",
 			"batchSize", len(txs),
 			"maxBatchSize", p.maxBatchSize,
 		)
 		return errors.New("batch size exceeds maximum allowed")
 	}
-	
+
 	batch := &TransactionBatch{
 		Transactions: txs,
 		Results:      make([]*TxResult, len(txs)),
 		Callback:     callback,
 	}
-	
-	log.Debug("Submitting transaction batch for processing", 
+
+	log.Debug("Submitting transaction batch for processing",
 		"batchSize", len(txs),
 		"queueSize", len(p.txPool),
 		"queueCapacity", cap(p.txPool),
 	)
-	
+
 	select {
 	case p.txPool <- batch:
 		log.Trace("Transaction batch successfully queued for processing")
@@ -543,7 +555,7 @@ func (p *GPUProcessor) ProcessTransactionsBatch(txs []*types.Transaction, callba
 		log.Debug("Transaction batch submission cancelled due to context cancellation")
 		return p.ctx.Err()
 	default:
-		log.Error("Transaction processing queue full, rejecting batch", 
+		log.Error("Transaction processing queue full, rejecting batch",
 			"batchSize", len(txs),
 			"queueSize", len(p.txPool),
 			"queueCapacity", cap(p.txPool),
@@ -556,7 +568,7 @@ func (p *GPUProcessor) ProcessTransactionsBatch(txs []*types.Transaction, callba
 func (p *GPUProcessor) hashWorker() {
 	defer p.wg.Done()
 	log.Debug("Hash worker started", "gpuType", p.gpuType)
-	
+
 	for {
 		select {
 		case <-p.ctx.Done():
@@ -565,7 +577,7 @@ func (p *GPUProcessor) hashWorker() {
 		case batch := <-p.hashPool:
 			log.Trace("Hash worker received batch", "batchSize", len(batch.Hashes))
 			start := time.Now()
-			
+
 			if p.gpuType == GPUTypeNone {
 				log.Trace("Processing hash batch on CPU (no GPU available)")
 				// CPU fallback
@@ -575,9 +587,9 @@ func (p *GPUProcessor) hashWorker() {
 				// GPU processing
 				p.processHashesGPU(batch)
 			}
-			
+
 			duration := time.Since(start)
-			log.Debug("Hash batch processing completed", 
+			log.Debug("Hash batch processing completed",
 				"batchSize", len(batch.Hashes),
 				"processingTime", duration,
 				"processingMode", func() string {
@@ -596,7 +608,7 @@ func (p *GPUProcessor) hashWorker() {
 func (p *GPUProcessor) signatureWorker() {
 	defer p.wg.Done()
 	log.Debug("Signature worker started", "gpuType", p.gpuType)
-	
+
 	for {
 		select {
 		case <-p.ctx.Done():
@@ -605,7 +617,7 @@ func (p *GPUProcessor) signatureWorker() {
 		case batch := <-p.signaturePool:
 			log.Trace("Signature worker received batch", "batchSize", len(batch.Signatures))
 			start := time.Now()
-			
+
 			if p.gpuType == GPUTypeNone {
 				log.Trace("Processing signature batch on CPU (no GPU available)")
 				// CPU fallback
@@ -615,9 +627,9 @@ func (p *GPUProcessor) signatureWorker() {
 				// GPU processing
 				p.processSignaturesGPU(batch)
 			}
-			
+
 			duration := time.Since(start)
-			log.Debug("Signature batch processing completed", 
+			log.Debug("Signature batch processing completed",
 				"batchSize", len(batch.Signatures),
 				"processingTime", duration,
 				"processingMode", func() string {
@@ -636,7 +648,7 @@ func (p *GPUProcessor) signatureWorker() {
 func (p *GPUProcessor) transactionWorker() {
 	defer p.wg.Done()
 	log.Debug("Transaction worker started", "gpuType", p.gpuType)
-	
+
 	for {
 		select {
 		case <-p.ctx.Done():
@@ -645,7 +657,7 @@ func (p *GPUProcessor) transactionWorker() {
 		case batch := <-p.txPool:
 			log.Trace("Transaction worker received batch", "batchSize", len(batch.Transactions))
 			start := time.Now()
-			
+
 			if p.gpuType == GPUTypeNone {
 				log.Trace("Processing transaction batch on CPU (no GPU available)")
 				// CPU fallback
@@ -655,9 +667,9 @@ func (p *GPUProcessor) transactionWorker() {
 				// GPU processing
 				p.processTransactionsGPU(batch)
 			}
-			
+
 			duration := time.Since(start)
-			log.Debug("Transaction batch processing completed", 
+			log.Debug("Transaction batch processing completed",
 				"batchSize", len(batch.Transactions),
 				"processingTime", duration,
 				"processingMode", func() string {
@@ -674,14 +686,14 @@ func (p *GPUProcessor) transactionWorker() {
 
 // processHashesGPU processes hashes using GPU acceleration
 func (p *GPUProcessor) processHashesGPU(batch *HashBatch) {
-	log.Debug("Starting GPU hash processing", 
+	log.Debug("Starting GPU hash processing",
 		"batchSize", len(batch.Hashes),
 		"gpuType", p.gpuType,
 	)
-	
+
 	defer func() {
 		if r := recover(); r != nil {
-			log.Error("GPU hash processing panicked", 
+			log.Error("GPU hash processing panicked",
 				"panic", r,
 				"batchSize", len(batch.Hashes),
 				"gpuType", p.gpuType,
@@ -696,8 +708,8 @@ func (p *GPUProcessor) processHashesGPU(batch *HashBatch) {
 	in := p.prepareHashData(batch.Hashes)
 	dataPreparationTime := time.Since(dataStart)
 	defer p.memoryPool.Put(in)
-	
-	log.Debug("Hash data preparation completed", 
+
+	log.Debug("Hash data preparation completed",
 		"inputSize", len(in),
 		"preparationTime", dataPreparationTime,
 	)
@@ -708,13 +720,13 @@ func (p *GPUProcessor) processHashesGPU(batch *HashBatch) {
 	log.Trace("Allocated output buffer", "size", len(out))
 
 	// Process on GPU
-	log.Debug("Executing GPU hash computation", 
+	log.Debug("Executing GPU hash computation",
 		"gpuType", p.gpuType,
 		"hashCount", count,
 		"inputBufferSize", len(in),
 		"outputBufferSize", len(out),
 	)
-	
+
 	gpuStart := time.Now()
 	var result int
 	switch p.gpuType {
@@ -725,7 +737,7 @@ func (p *GPUProcessor) processHashesGPU(batch *HashBatch) {
 			C.int(count),
 			unsafe.Pointer(&out[0]),
 		))
-		log.Debug("CUDA hash processing completed", 
+		log.Debug("CUDA hash processing completed",
 			"result", result,
 			"duration", time.Since(gpuStart),
 		)
@@ -736,16 +748,16 @@ func (p *GPUProcessor) processHashesGPU(batch *HashBatch) {
 			C.int(count),
 			unsafe.Pointer(&out[0]),
 		))
-		log.Debug("OpenCL hash processing completed", 
+		log.Debug("OpenCL hash processing completed",
 			"result", result,
 			"duration", time.Since(gpuStart),
 		)
 	}
-	
+
 	gpuProcessingTime := time.Since(gpuStart)
 
 	if result != 0 {
-		log.Warn("GPU hash processing failed, falling back to CPU", 
+		log.Warn("GPU hash processing failed, falling back to CPU",
 			"error", result,
 			"gpuType", p.gpuType,
 			"batchSize", count,
@@ -765,8 +777,8 @@ func (p *GPUProcessor) processHashesGPU(batch *HashBatch) {
 		batch.Results[i] = dst
 	}
 	conversionTime := time.Since(conversionStart)
-	
-	log.Debug("GPU hash processing completed successfully", 
+
+	log.Debug("GPU hash processing completed successfully",
 		"batchSize", count,
 		"gpuType", p.gpuType,
 		"dataPreparationTime", dataPreparationTime,
@@ -786,7 +798,7 @@ func (p *GPUProcessor) processHashesCPU(batch *HashBatch) {
 		result := crypto.Keccak256(hash)
 		batch.Results[i] = result
 	}
-	
+
 	if batch.Callback != nil {
 		batch.Callback(batch.Results, nil)
 	}
@@ -794,14 +806,14 @@ func (p *GPUProcessor) processHashesCPU(batch *HashBatch) {
 
 // processSignaturesGPU processes signature verification using GPU
 func (p *GPUProcessor) processSignaturesGPU(batch *SignatureBatch) {
-	log.Debug("Starting GPU signature verification", 
+	log.Debug("Starting GPU signature verification",
 		"batchSize", len(batch.Signatures),
 		"gpuType", p.gpuType,
 	)
-	
+
 	defer func() {
 		if r := recover(); r != nil {
-			log.Error("GPU signature processing panicked", 
+			log.Error("GPU signature processing panicked",
 				"panic", r,
 				"batchSize", len(batch.Signatures),
 				"gpuType", p.gpuType,
@@ -816,8 +828,8 @@ func (p *GPUProcessor) processSignaturesGPU(batch *SignatureBatch) {
 	packed := p.prepareSignatureData(batch.Signatures, batch.Messages, batch.PublicKeys)
 	dataPreparationTime := time.Since(dataStart)
 	defer p.memoryPool.Put(packed)
-	
-	log.Debug("Signature data preparation completed", 
+
+	log.Debug("Signature data preparation completed",
 		"packedSize", len(packed),
 		"preparationTime", dataPreparationTime,
 	)
@@ -828,54 +840,55 @@ func (p *GPUProcessor) processSignaturesGPU(batch *SignatureBatch) {
 	log.Trace("Allocated signature output buffer", "size", len(out))
 
 	// Process on GPU
-	log.Debug("Executing GPU signature verification", 
+	log.Debug("Executing GPU signature verification",
 		"gpuType", p.gpuType,
 		"signatureCount", count,
 		"inputBufferSize", len(packed),
 		"outputBufferSize", len(out),
 	)
-	
+
 	gpuStart := time.Now()
 	var result int
 	switch p.gpuType {
-	case GPUTypeCUDA: {
-		log.Trace("Preparing CUDA signature buffers")
-		// CUDA expects separate buffers for signatures, messages, and pubkeys
-		bufferStart := time.Now()
-		sigs := make([]byte, count*65)
-		msgs := make([]byte, count*32)
-		keys := make([]byte, count*64)
-		for i := 0; i < count; i++ {
-			copy(sigs[i*65:(i+1)*65], batch.Signatures[i])
-			copy(msgs[i*32:(i+1)*32], batch.Messages[i])
-			copy(keys[i*64:(i+1)*64], batch.PublicKeys[i])
+	case GPUTypeCUDA:
+		{
+			log.Trace("Preparing CUDA signature buffers")
+			// CUDA expects separate buffers for signatures, messages, and pubkeys
+			bufferStart := time.Now()
+			sigs := make([]byte, count*65)
+			msgs := make([]byte, count*32)
+			keys := make([]byte, count*64)
+			for i := 0; i < count; i++ {
+				copy(sigs[i*65:(i+1)*65], batch.Signatures[i])
+				copy(msgs[i*32:(i+1)*32], batch.Messages[i])
+				copy(keys[i*64:(i+1)*64], batch.PublicKeys[i])
+			}
+			bufferPreparationTime := time.Since(bufferStart)
+
+			log.Debug("CUDA signature buffers prepared",
+				"sigsSize", len(sigs),
+				"msgsSize", len(msgs),
+				"keysSize", len(keys),
+				"bufferPreparationTime", bufferPreparationTime,
+			)
+
+			log.Trace("Calling CUDA signature verification kernel")
+			kernelStart := time.Now()
+			result = int(C.cuda_verify_signatures(
+				unsafe.Pointer(&sigs[0]),
+				unsafe.Pointer(&msgs[0]),
+				unsafe.Pointer(&keys[0]),
+				C.int(count),
+				unsafe.Pointer(&out[0]),
+			))
+			kernelTime := time.Since(kernelStart)
+
+			log.Debug("CUDA signature verification completed",
+				"result", result,
+				"kernelTime", kernelTime,
+				"totalCudaTime", time.Since(gpuStart),
+			)
 		}
-		bufferPreparationTime := time.Since(bufferStart)
-		
-		log.Debug("CUDA signature buffers prepared", 
-			"sigsSize", len(sigs),
-			"msgsSize", len(msgs),
-			"keysSize", len(keys),
-			"bufferPreparationTime", bufferPreparationTime,
-		)
-		
-		log.Trace("Calling CUDA signature verification kernel")
-		kernelStart := time.Now()
-		result = int(C.cuda_verify_signatures(
-			unsafe.Pointer(&sigs[0]),
-			unsafe.Pointer(&msgs[0]),
-			unsafe.Pointer(&keys[0]),
-			C.int(count),
-			unsafe.Pointer(&out[0]),
-		))
-		kernelTime := time.Since(kernelStart)
-		
-		log.Debug("CUDA signature verification completed", 
-			"result", result,
-			"kernelTime", kernelTime,
-			"totalCudaTime", time.Since(gpuStart),
-		)
-	}
 	case GPUTypeOpenCL:
 		log.Trace("Calling OpenCL signature verification kernel")
 		result = int(C.verifySignaturesOpenCL(
@@ -883,16 +896,16 @@ func (p *GPUProcessor) processSignaturesGPU(batch *SignatureBatch) {
 			C.int(count),
 			unsafe.Pointer(&out[0]),
 		))
-		log.Debug("OpenCL signature verification completed", 
+		log.Debug("OpenCL signature verification completed",
 			"result", result,
 			"duration", time.Since(gpuStart),
 		)
 	}
-	
+
 	gpuProcessingTime := time.Since(gpuStart)
 
 	if result != 0 {
-		log.Warn("GPU signature processing failed, falling back to CPU", 
+		log.Warn("GPU signature processing failed, falling back to CPU",
 			"error", result,
 			"gpuType", p.gpuType,
 			"batchSize", count,
@@ -913,8 +926,8 @@ func (p *GPUProcessor) processSignaturesGPU(batch *SignatureBatch) {
 		}
 	}
 	conversionTime := time.Since(conversionStart)
-	
-	log.Debug("GPU signature verification completed successfully", 
+
+	log.Debug("GPU signature verification completed successfully",
 		"batchSize", count,
 		"validSignatures", validCount,
 		"invalidSignatures", count-validCount,
@@ -950,28 +963,28 @@ func (p *GPUProcessor) processSignaturesCPU(batch *SignatureBatch) {
 // processTransactionsGPU processes transactions using GPU with full execution context
 func (p *GPUProcessor) processTransactionsGPU(batch *TransactionBatch) {
 	// GPU ACTIVATION LOG - This proves GPU is processing real transactions
-	log.Info("🚀 GPU TRANSACTION PROCESSING ACTIVATED", 
+	log.Info("🚀 GPU TRANSACTION PROCESSING ACTIVATED",
 		"batchSize", len(batch.Transactions),
 		"gpuType", p.gpuType,
 		"timestamp", time.Now().Format("2006-01-02 15:04:05.000"),
 		"deviceCount", p.deviceCount,
 	)
-	
+
 	// Save to GPU log file
-	logging.LogGPU("INFO", "GPU TRANSACTION PROCESSING ACTIVATED", 
+	logging.LogGPU("INFO", "GPU TRANSACTION PROCESSING ACTIVATED",
 		"batchSize", len(batch.Transactions),
 		"gpuType", p.gpuType,
 		"deviceCount", p.deviceCount,
 	)
-	
-	log.Debug("Starting enhanced GPU transaction processing", 
+
+	log.Debug("Starting enhanced GPU transaction processing",
 		"batchSize", len(batch.Transactions),
 		"gpuType", p.gpuType,
 	)
-	
+
 	defer func() {
 		if r := recover(); r != nil {
-			log.Error("GPU transaction processing panicked", 
+			log.Error("GPU transaction processing panicked",
 				"panic", r,
 				"batchSize", len(batch.Transactions),
 				"gpuType", p.gpuType,
@@ -980,25 +993,25 @@ func (p *GPUProcessor) processTransactionsGPU(batch *TransactionBatch) {
 		}
 	}()
 
-    // If per-sender scheduling is enabled, slice the batch into conflict-free microbatches
-    if p.enablePerSender && len(batch.Transactions) > 0 {
-        p.processTransactionsGPUTiered(batch)
-        return
-    }
+	// If per-sender scheduling is enabled, slice the batch into conflict-free microbatches
+	if p.enablePerSender && len(batch.Transactions) > 0 {
+		p.processTransactionsGPUTiered(batch)
+		return
+	}
 
-    count := len(batch.Transactions)
-    dataStart := time.Now()
-	
-    // Prepare transaction data (1KB per transaction)
-    log.Trace("Preparing transaction data for GPU processing", "txCount", count)
-    txData := p.prepareTransactionData(batch.Transactions)
-    defer p.memoryPool.Put(txData)
-    // Prepare per-transaction lengths
-    txLens := p.prepareTransactionLengths(batch.Transactions)
+	count := len(batch.Transactions)
+	dataStart := time.Now()
 
-    // Prepare signing hashes (32B each) using canonical signer on CPU
-    signHashesBuf, _ := p.prepareSigningHashes(batch.Transactions)
-	
+	// Prepare transaction data (1KB per transaction)
+	log.Trace("Preparing transaction data for GPU processing", "txCount", count)
+	txData := p.prepareTransactionData(batch.Transactions)
+	defer p.memoryPool.Put(txData)
+	// Prepare per-transaction lengths
+	txLens := p.prepareTransactionLengths(batch.Transactions)
+
+	// Prepare signing hashes (32B each) using canonical signer on CPU
+	signHashesBuf, _ := p.prepareSigningHashes(batch.Transactions)
+
 	// Prepare state snapshots (2KB per transaction)
 	log.Trace("Preparing state snapshots for GPU processing")
 	stateData := p.prepareStateSnapshots(batch.Transactions)
@@ -1007,7 +1020,7 @@ func (p *GPUProcessor) processTransactionsGPU(batch *TransactionBatch) {
 			p.memoryPool.Put(stateData)
 		}
 	}()
-	
+
 	// Prepare access lists (512B per transaction)
 	log.Trace("Preparing access lists for GPU processing")
 	accessLists := p.prepareAccessLists(batch.Transactions)
@@ -1016,9 +1029,9 @@ func (p *GPUProcessor) processTransactionsGPU(batch *TransactionBatch) {
 			p.memoryPool.Put(accessLists)
 		}
 	}()
-	
+
 	dataPreparationTime := time.Since(dataStart)
-	log.Debug("Enhanced transaction data preparation completed", 
+	log.Debug("Enhanced transaction data preparation completed",
 		"txDataSize", len(txData),
 		"stateDataSize", func() int {
 			if stateData != nil {
@@ -1040,72 +1053,72 @@ func (p *GPUProcessor) processTransactionsGPU(batch *TransactionBatch) {
 	log.Trace("Allocated enhanced transaction output buffer", "size", len(out))
 
 	// Process on GPU with full execution context
-	log.Debug("Executing enhanced GPU transaction computation", 
+	log.Debug("Executing enhanced GPU transaction computation",
 		"gpuType", p.gpuType,
 		"txCount", count,
 		"inputBufferSize", len(txData),
 		"outputBufferSize", len(out),
 	)
-	
+
 	gpuStart := time.Now()
 	var result int
-    switch p.gpuType {
-    case GPUTypeCUDA:
-        log.Trace("Calling enhanced CUDA transaction processing kernel")
-        result = int(C.cuda_process_transactions_full(
-            unsafe.Pointer(&txData[0]),
-            unsafe.Pointer(&txLens[0]),
-            func() unsafe.Pointer {
-                if stateData != nil {
-                    return unsafe.Pointer(&stateData[0])
-                }
-                return nil
-            }(),
-            func() unsafe.Pointer {
-                if accessLists != nil {
-                    return unsafe.Pointer(&accessLists[0])
-                }
-                return nil
-            }(),
-            unsafe.Pointer(&signHashesBuf[0]),
-            C.int(count),
-            unsafe.Pointer(&out[0]),
-        ))
-		log.Debug("Enhanced CUDA transaction processing completed", 
+	switch p.gpuType {
+	case GPUTypeCUDA:
+		log.Trace("Calling enhanced CUDA transaction processing kernel")
+		result = int(C.cuda_process_transactions_full(
+			unsafe.Pointer(&txData[0]),
+			unsafe.Pointer(&txLens[0]),
+			func() unsafe.Pointer {
+				if stateData != nil {
+					return unsafe.Pointer(&stateData[0])
+				}
+				return nil
+			}(),
+			func() unsafe.Pointer {
+				if accessLists != nil {
+					return unsafe.Pointer(&accessLists[0])
+				}
+				return nil
+			}(),
+			unsafe.Pointer(&signHashesBuf[0]),
+			C.int(count),
+			unsafe.Pointer(&out[0]),
+		))
+		log.Debug("Enhanced CUDA transaction processing completed",
 			"result", result,
 			"duration", time.Since(gpuStart),
 		)
-    case GPUTypeOpenCL:
-        log.Trace("Calling enhanced OpenCL transaction processing kernel")
-        result = int(C.processTxBatchOpenCLFull(
-            unsafe.Pointer(&txData[0]),
-            unsafe.Pointer(&txLens[0]),
-            func() unsafe.Pointer {
-                if stateData != nil {
-                    return unsafe.Pointer(&stateData[0])
-                }
-                return nil
-            }(),
-            func() unsafe.Pointer {
-                if accessLists != nil {
-                    return unsafe.Pointer(&accessLists[0])
-                }
-                return nil
-            }(),
-            unsafe.Pointer(&signHashesBuf[0]),
-            C.int(count),
-            unsafe.Pointer(&out[0]),
-        ))
-		log.Debug("Enhanced OpenCL transaction processing completed", 
+	case GPUTypeOpenCL:
+		log.Trace("Calling enhanced OpenCL transaction processing kernel")
+		result = int(C.processTxBatchOpenCLFull(
+			unsafe.Pointer(&txData[0]),
+			unsafe.Pointer(&txLens[0]),
+			func() unsafe.Pointer {
+				if stateData != nil {
+					return unsafe.Pointer(&stateData[0])
+				}
+				return nil
+			}(),
+			func() unsafe.Pointer {
+				if accessLists != nil {
+					return unsafe.Pointer(&accessLists[0])
+				}
+				return nil
+			}(),
+			unsafe.Pointer(&signHashesBuf[0]),
+			C.int(count),
+			unsafe.Pointer(&out[0]),
+		))
+		log.Debug("Enhanced OpenCL transaction processing completed",
 			"result", result,
 			"duration", time.Since(gpuStart),
 		)
 	}
-	
+
 	gpuProcessingTime := time.Since(gpuStart)
 
 	if result != 0 {
-		log.Warn("Enhanced GPU transaction processing failed, falling back to CPU", 
+		log.Warn("Enhanced GPU transaction processing failed, falling back to CPU",
 			"error", result,
 			"gpuType", p.gpuType,
 			"batchSize", count,
@@ -1115,27 +1128,27 @@ func (p *GPUProcessor) processTransactionsGPU(batch *TransactionBatch) {
 		return
 	}
 
-    // Parallel CPU ECDSA verification using signing-hash from GPU results
-    cpuSigStart := time.Now()
-    sigValid := p.verifyBatchECDSAWithSigningHash(batch.Transactions, out, count)
-    cpuSigTime := time.Since(cpuSigStart)
+	// Parallel CPU ECDSA verification using signing-hash from GPU results
+	cpuSigStart := time.Now()
+	sigValid := p.verifyBatchECDSAWithSigningHash(batch.Transactions, out, count)
+	cpuSigTime := time.Since(cpuSigStart)
 
-    // Convert enhanced results
-    log.Trace("Converting enhanced GPU transaction results")
+	// Convert enhanced results
+	log.Trace("Converting enhanced GPU transaction results")
 	conversionStart := time.Now()
 	validCount := 0
 	successCount := 0
 	revertCount := 0
 	outOfGasCount := 0
 	invalidCount := 0
-	
+
 	for i := 0; i < count; i++ {
 		offset := i * 160
 
 		if batch.Results[i] == nil {
 			batch.Results[i] = &TxResult{}
 		}
-		
+
 		// Enhanced result structure (160 bytes):
 		// [0-31]:   transaction hash
 		// [32]:     validity flag
@@ -1145,23 +1158,23 @@ func (p *GPUProcessor) processTransactionsGPU(batch *TransactionBatch) {
 		// [74-105]: revert reason hash (32 bytes)
 		// [106-137]: signing-hash (32 bytes)
 		// [138-159]: reserved
-		
+
 		// Extract transaction hash
 		var txHash common.Hash
 		copy(txHash[:], out[offset:offset+32])
 		batch.Results[i].Hash = txHash
-		
+
 		// Extract validity and execution status
 		valid := out[offset+32] != 0
 		execStatus := out[offset+33]
-		
-        // Final validity gate: must pass CPU signature verification
-        if valid && !sigValid[i] {
-            valid = false
-            execStatus = 3 // invalid
-        }
-        batch.Results[i].Valid = valid
-		
+
+		// Final validity gate: must pass CPU signature verification
+		if valid && !sigValid[i] {
+			valid = false
+			execStatus = 3 // invalid
+		}
+		batch.Results[i].Valid = valid
+
 		// Extract gas used
 		gasUsed := binary.LittleEndian.Uint64(out[offset+34 : offset+42])
 		if gasUsed > 0 {
@@ -1169,7 +1182,7 @@ func (p *GPUProcessor) processTransactionsGPU(batch *TransactionBatch) {
 		} else {
 			batch.Results[i].GasUsed = batch.Transactions[i].Gas()
 		}
-		
+
 		// Set error based on execution status
 		switch execStatus {
 		case 0: // success
@@ -1185,22 +1198,22 @@ func (p *GPUProcessor) processTransactionsGPU(batch *TransactionBatch) {
 			batch.Results[i].Error = errors.New("invalid transaction")
 			invalidCount++
 		}
-		
+
 		if valid {
 			validCount++
 		}
 	}
 	conversionTime := time.Since(conversionStart)
-	
+
 	// Calculate TPS for this batch
 	totalTime := time.Since(dataStart)
 	var tps float64
 	if totalTime > 0 {
 		tps = float64(count) / totalTime.Seconds()
 	}
-	
+
 	// Enhanced GPU PERFORMANCE LOG
-    log.Info("✅ ENHANCED GPU TRANSACTION BATCH COMPLETED", 
+	log.Info("✅ ENHANCED GPU TRANSACTION BATCH COMPLETED",
 		"batchSize", count,
 		"validTransactions", validCount,
 		"successfulExecutions", successCount,
@@ -1209,14 +1222,14 @@ func (p *GPUProcessor) processTransactionsGPU(batch *TransactionBatch) {
 		"invalidTransactions", invalidCount,
 		"gpuType", p.gpuType,
 		"batchTPS", tps,
-        "gpuKernelTime", gpuProcessingTime,
-        "cpuSigVerifyTime", cpuSigTime,
-        "totalProcessingTime", totalTime,
-        "timestamp", time.Now().Format("2006-01-02 15:04:05.000"),
-    )
-	
+		"gpuKernelTime", gpuProcessingTime,
+		"cpuSigVerifyTime", cpuSigTime,
+		"totalProcessingTime", totalTime,
+		"timestamp", time.Now().Format("2006-01-02 15:04:05.000"),
+	)
+
 	// Save enhanced performance data to files
-	logging.LogGPU("INFO", "ENHANCED GPU TRANSACTION BATCH COMPLETED", 
+	logging.LogGPU("INFO", "ENHANCED GPU TRANSACTION BATCH COMPLETED",
 		"batchSize", count,
 		"validTransactions", validCount,
 		"successfulExecutions", successCount,
@@ -1228,16 +1241,16 @@ func (p *GPUProcessor) processTransactionsGPU(batch *TransactionBatch) {
 		"gpuKernelTime", gpuProcessingTime,
 		"totalProcessingTime", totalTime,
 	)
-	
-	logging.LogPerformance("INFO", "ENHANCED BATCH PERFORMANCE METRICS", 
+
+	logging.LogPerformance("INFO", "ENHANCED BATCH PERFORMANCE METRICS",
 		"batchSize", count,
 		"batchTPS", tps,
 		"processingMode", "Enhanced GPU",
 		"kernelTime", gpuProcessingTime,
 		"totalTime", totalTime,
 	)
-	
-	logging.LogTransaction("INFO", "ENHANCED TRANSACTION BATCH PROCESSED", 
+
+	logging.LogTransaction("INFO", "ENHANCED TRANSACTION BATCH PROCESSED",
 		"batchSize", count,
 		"validTransactions", validCount,
 		"successfulExecutions", successCount,
@@ -1246,8 +1259,8 @@ func (p *GPUProcessor) processTransactionsGPU(batch *TransactionBatch) {
 		"invalidTransactions", invalidCount,
 		"processingMode", "Enhanced GPU",
 	)
-	
-	log.Debug("Enhanced GPU transaction processing completed successfully", 
+
+	log.Debug("Enhanced GPU transaction processing completed successfully",
 		"batchSize", count,
 		"validTransactions", validCount,
 		"successfulExecutions", successCount,
@@ -1270,214 +1283,297 @@ func (p *GPUProcessor) processTransactionsGPU(batch *TransactionBatch) {
 // processTransactionsGPUTiered schedules txs per-sender to form conflict-free slices
 // and adaptively sizes slices to keep kernel runtime around targetKernelMs.
 func (p *GPUProcessor) processTransactionsGPUTiered(batch *TransactionBatch) {
-    txs := batch.Transactions
-    n := len(txs)
-    results := make([]*TxResult, n)
-    if batch.Results != nil && len(batch.Results) == n {
-        results = batch.Results
-    }
+	txs := batch.Transactions
+	n := len(txs)
+	results := make([]*TxResult, n)
+	if batch.Results != nil && len(batch.Results) == n {
+		results = batch.Results
+	}
 
-    // Compute senders (parallel recovery)
-    type item struct{ idx int; tx *types.Transaction; sender common.Address; sigOK bool }
-    items := make([]item, n)
-    // Parallel sender recovery using verifyTxSignatureCPU which fills cache for Sender
-    workers := p.configuredSigWorkers()
-    jobs := make(chan int, n)
-    var wg sync.WaitGroup
-    for w := 0; w < workers; w++ {
-        wg.Add(1)
-        go func() {
-            defer wg.Done()
-            for i := range jobs {
-                tx := txs[i]
-                // Derive signer by chain ID
-                chainID := tx.ChainId(); if chainID == nil { chainID = new(big.Int) }
-                signer := types.LatestSignerForChainID(chainID)
-                from, err := types.Sender(signer, tx)
-                if err != nil {
-                    // Leave zero address; mark signature invalid
-                    items[i] = item{idx: i, tx: tx, sigOK: false}
-                    continue
-                }
-                items[i] = item{idx: i, tx: tx, sender: from, sigOK: true}
-            }
-        }()
-    }
-    for i := 0; i < n; i++ { jobs <- i }
-    close(jobs)
-    wg.Wait()
+	// Compute senders (parallel recovery)
+	type item struct {
+		idx    int
+		tx     *types.Transaction
+		sender common.Address
+		sigOK  bool
+	}
+	items := make([]item, n)
+	// Parallel sender recovery using verifyTxSignatureCPU which fills cache for Sender
+	workers := p.configuredSigWorkers()
+	jobs := make(chan int, n)
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := range jobs {
+				tx := txs[i]
+				// Derive signer by chain ID
+				chainID := tx.ChainId()
+				if chainID == nil {
+					chainID = new(big.Int)
+				}
+				signer := types.LatestSignerForChainID(chainID)
+				from, err := types.Sender(signer, tx)
+				if err != nil {
+					// Leave zero address; mark signature invalid
+					items[i] = item{idx: i, tx: tx, sigOK: false}
+					continue
+				}
+				items[i] = item{idx: i, tx: tx, sender: from, sigOK: true}
+			}
+		}()
+	}
+	for i := 0; i < n; i++ {
+		jobs <- i
+	}
+	close(jobs)
+	wg.Wait()
 
-    // Build per-sender queues
-    bySender := make(map[common.Address][]item, n/2)
-    order := make([]common.Address, 0, n/2)
-    for _, it := range items {
-        q := bySender[it.sender]
-        if q == nil {
-            order = append(order, it.sender)
-        }
-        bySender[it.sender] = append(q, it)
-    }
+	// Build per-sender queues
+	bySender := make(map[common.Address][]item, n/2)
+	order := make([]common.Address, 0, n/2)
+	for _, it := range items {
+		q := bySender[it.sender]
+		if q == nil {
+			order = append(order, it.sender)
+		}
+		bySender[it.sender] = append(q, it)
+	}
 
-    // Round-robin pop one per sender into slices
-    sliceSize := p.nextSliceSize
-    if sliceSize <= 0 { sliceSize = 65536 }
-    target := time.Duration(p.targetKernelMs) * time.Millisecond
-    var totalValid, totalSuccess, totalRevert, totalOOG, totalInvalid int
-    startBatch := time.Now()
-    var convWG sync.WaitGroup
+	// Round-robin pop one per sender into slices
+	sliceSize := p.nextSliceSize
+	if sliceSize <= 0 {
+		sliceSize = 65536
+	}
+	target := time.Duration(p.targetKernelMs) * time.Millisecond
+	var totalValid, totalSuccess, totalRevert, totalOOG, totalInvalid int
+	startBatch := time.Now()
+	var convWG sync.WaitGroup
 
-    for remaining := n; remaining > 0; {
-        // Form a slice
-        sel := make([]item, 0, min(sliceSize, remaining))
-        // maintain list of active senders
-        active := order[:0]
-        for _, s := range order { if len(bySender[s]) > 0 { active = append(active, s) } }
-        order = active
-        for len(sel) < cap(sel) && len(order) > 0 {
-            newOrder := order[:0]
-            for _, s := range order {
-                q := bySender[s]
-                if len(q) == 0 { continue }
-                sel = append(sel, q[0])
-                if len(sel) >= cap(sel) { bySender[s] = q[1:]; newOrder = append(newOrder, s); break }
-                bySender[s] = q[1:]
-                if len(bySender[s]) > 0 { newOrder = append(newOrder, s) }
-            }
-            order = newOrder
-        }
-        if len(sel) == 0 { break }
+	for remaining := n; remaining > 0; {
+		// Form a slice
+		sel := make([]item, 0, min(sliceSize, remaining))
+		// maintain list of active senders
+		active := order[:0]
+		for _, s := range order {
+			if len(bySender[s]) > 0 {
+				active = append(active, s)
+			}
+		}
+		order = active
+		for len(sel) < cap(sel) && len(order) > 0 {
+			newOrder := order[:0]
+			for _, s := range order {
+				q := bySender[s]
+				if len(q) == 0 {
+					continue
+				}
+				sel = append(sel, q[0])
+				if len(sel) >= cap(sel) {
+					bySender[s] = q[1:]
+					newOrder = append(newOrder, s)
+					break
+				}
+				bySender[s] = q[1:]
+				if len(bySender[s]) > 0 {
+					newOrder = append(newOrder, s)
+				}
+			}
+			order = newOrder
+		}
+		if len(sel) == 0 {
+			break
+		}
 
-        // Execute this slice on GPU
-        sliceTxs := make([]*types.Transaction, len(sel))
-        indexMap := make([]int, len(sel))
-        sigOKs := make([]bool, len(sel))
-        for i, it := range sel { sliceTxs[i] = it.tx; indexMap[i] = it.idx; sigOKs[i] = it.sigOK }
+		// Execute this slice on GPU
+		sliceTxs := make([]*types.Transaction, len(sel))
+		indexMap := make([]int, len(sel))
+		sigOKs := make([]bool, len(sel))
+		for i, it := range sel {
+			sliceTxs[i] = it.tx
+			indexMap[i] = it.idx
+			sigOKs[i] = it.sigOK
+		}
 
-        sliceStart := time.Now()
-        // Prepare buffers per slice
-        txData := p.prepareTransactionData(sliceTxs)
-        txLens := p.prepareTransactionLengths(sliceTxs)
-        stateData := p.prepareStateSnapshots(sliceTxs)
-        accessLists := p.prepareAccessLists(sliceTxs)
-        // No signing-hash buffer needed when reusing Sender() validity
-        var signHashesPtr unsafe.Pointer = nil
-        out := make([]byte, len(sliceTxs)*160)
+		sliceStart := time.Now()
+		// Prepare buffers per slice
+		txData := p.prepareTransactionData(sliceTxs)
+		txLens := p.prepareTransactionLengths(sliceTxs)
+		stateData := p.prepareStateSnapshots(sliceTxs)
+		accessLists := p.prepareAccessLists(sliceTxs)
+		// No signing-hash buffer needed when reusing Sender() validity
+		var signHashesPtr unsafe.Pointer = nil
+		out := make([]byte, len(sliceTxs)*160)
 
-        var rc int
-        switch p.gpuType {
-        case GPUTypeCUDA:
-            rc = int(C.cuda_process_transactions_full(
-                unsafe.Pointer(&txData[0]),
-                unsafe.Pointer(&txLens[0]),
-                func() unsafe.Pointer { if stateData != nil { return unsafe.Pointer(&stateData[0]) }; return nil }(),
-                func() unsafe.Pointer { if accessLists != nil { return unsafe.Pointer(&accessLists[0]) }; return nil }(),
-                signHashesPtr,
-                C.int(len(sliceTxs)),
-                unsafe.Pointer(&out[0]),
-            ))
-        case GPUTypeOpenCL:
-            rc = int(C.processTxBatchOpenCLFull(
-                unsafe.Pointer(&txData[0]),
-                unsafe.Pointer(&txLens[0]),
-                func() unsafe.Pointer { if stateData != nil { return unsafe.Pointer(&stateData[0]) }; return nil }(),
-                func() unsafe.Pointer { if accessLists != nil { return unsafe.Pointer(&accessLists[0]) }; return nil }(),
-                signHashesPtr,
-                C.int(len(sliceTxs)),
-                unsafe.Pointer(&out[0]),
-            ))
-        }
+		var rc int
+		switch p.gpuType {
+		case GPUTypeCUDA:
+			rc = int(C.cuda_process_transactions_full(
+				unsafe.Pointer(&txData[0]),
+				unsafe.Pointer(&txLens[0]),
+				func() unsafe.Pointer {
+					if stateData != nil {
+						return unsafe.Pointer(&stateData[0])
+					}
+					return nil
+				}(),
+				func() unsafe.Pointer {
+					if accessLists != nil {
+						return unsafe.Pointer(&accessLists[0])
+					}
+					return nil
+				}(),
+				signHashesPtr,
+				C.int(len(sliceTxs)),
+				unsafe.Pointer(&out[0]),
+			))
+		case GPUTypeOpenCL:
+			rc = int(C.processTxBatchOpenCLFull(
+				unsafe.Pointer(&txData[0]),
+				unsafe.Pointer(&txLens[0]),
+				func() unsafe.Pointer {
+					if stateData != nil {
+						return unsafe.Pointer(&stateData[0])
+					}
+					return nil
+				}(),
+				func() unsafe.Pointer {
+					if accessLists != nil {
+						return unsafe.Pointer(&accessLists[0])
+					}
+					return nil
+				}(),
+				signHashesPtr,
+				C.int(len(sliceTxs)),
+				unsafe.Pointer(&out[0]),
+			))
+		}
 
-        kernelDur := time.Since(sliceStart)
-        // Release buffers promptly
-        p.memoryPool.Put(txData)
-        if stateData != nil { p.memoryPool.Put(stateData) }
-        if accessLists != nil { p.memoryPool.Put(accessLists) }
-        if rc != 0 {
-            log.Warn("GPU slice failed, falling back to CPU", "size", len(sliceTxs), "err", rc)
-            // CPU fallback per slice
-            tmpBatch := &TransactionBatch{Transactions: sliceTxs, Results: make([]*TxResult, len(sliceTxs))}
-            p.processTransactionsCPU(tmpBatch)
-            for i := range sliceTxs { results[indexMap[i]] = tmpBatch.Results[i] }
-        } else {
-            // Convert and place results asynchronously to overlap with next slice
-            convWG.Add(1)
-            go func(sliceTxs []*types.Transaction, indexMap []int, out []byte, sigOKs []bool) {
-                defer convWG.Done()
-                for i := 0; i < len(sliceTxs); i++ {
-                    off := i * 160
-                    r := results[indexMap[i]]
-                    if r == nil { r = &TxResult{}; results[indexMap[i]] = r }
-                    var h common.Hash; copy(h[:], out[off:off+32]); r.Hash = h
-                    valid := out[off+32] != 0
-                    status := out[off+33]
-                    // Final gate via Sender() result
-                    if valid && !sigOKs[i] { valid = false; status = 3 }
-                    r.Valid = valid
-                    r.GasUsed = binary.LittleEndian.Uint64(out[off+34 : off+42])
-                    switch status {
-                    case 0:
-                        r.Error = nil
-                    case 1:
-                        r.Error = errors.New("execution reverted")
-                    case 2:
-                        r.Error = errors.New("out of gas")
-                    default:
-                        r.Error = errors.New("invalid transaction")
-                    }
-                }
-            }(sliceTxs, indexMap, out, sigOKs)
-        }
+		kernelDur := time.Since(sliceStart)
+		// Release buffers promptly
+		p.memoryPool.Put(txData)
+		if stateData != nil {
+			p.memoryPool.Put(stateData)
+		}
+		if accessLists != nil {
+			p.memoryPool.Put(accessLists)
+		}
+		if rc != 0 {
+			log.Warn("GPU slice failed, falling back to CPU", "size", len(sliceTxs), "err", rc)
+			// CPU fallback per slice
+			tmpBatch := &TransactionBatch{Transactions: sliceTxs, Results: make([]*TxResult, len(sliceTxs))}
+			p.processTransactionsCPU(tmpBatch)
+			for i := range sliceTxs {
+				results[indexMap[i]] = tmpBatch.Results[i]
+			}
+		} else {
+			// Convert and place results asynchronously to overlap with next slice
+			convWG.Add(1)
+			go func(sliceTxs []*types.Transaction, indexMap []int, out []byte, sigOKs []bool) {
+				defer convWG.Done()
+				for i := 0; i < len(sliceTxs); i++ {
+					off := i * 160
+					r := results[indexMap[i]]
+					if r == nil {
+						r = &TxResult{}
+						results[indexMap[i]] = r
+					}
+					var h common.Hash
+					copy(h[:], out[off:off+32])
+					r.Hash = h
+					valid := out[off+32] != 0
+					status := out[off+33]
+					// Final gate via Sender() result
+					if valid && !sigOKs[i] {
+						valid = false
+						status = 3
+					}
+					r.Valid = valid
+					r.GasUsed = binary.LittleEndian.Uint64(out[off+34 : off+42])
+					switch status {
+					case 0:
+						r.Error = nil
+					case 1:
+						r.Error = errors.New("execution reverted")
+					case 2:
+						r.Error = errors.New("out of gas")
+					default:
+						r.Error = errors.New("invalid transaction")
+					}
+				}
+			}(sliceTxs, indexMap, out, sigOKs)
+		}
 
-        // Adapt slice size to keep under target
-        switch {
-        case kernelDur > target+target/5: // >120% target, reduce 20%
-            sliceSize = max(p.minSliceSize, (sliceSize*80)/100)
-        case kernelDur < target-target/5: // <80% target, increase 10%
-            sliceSize = min(p.maxSliceSize, (sliceSize*110)/100)
-        }
-    }
+		// Adapt slice size to keep under target
+		switch {
+		case kernelDur > target+target/5: // >120% target, reduce 20%
+			sliceSize = max(p.minSliceSize, (sliceSize*80)/100)
+		case kernelDur < target-target/5: // <80% target, increase 10%
+			sliceSize = min(p.maxSliceSize, (sliceSize*110)/100)
+		}
+	}
 
-    // Wait for all conversions to finish
-    convWG.Wait()
-    // Commit adaptive size for next batch
-    p.nextSliceSize = sliceSize
+	// Wait for all conversions to finish
+	convWG.Wait()
+	// Commit adaptive size for next batch
+	p.nextSliceSize = sliceSize
 
-    // Assign back and callback
-    batch.Results = results
-    if batch.Callback != nil {
-        batch.Callback(batch.Results, nil)
-    }
+	// Assign back and callback
+	batch.Results = results
+	if batch.Callback != nil {
+		batch.Callback(batch.Results, nil)
+	}
 
-    // Aggregate stats from results
-    totalValid, totalSuccess, totalRevert, totalOOG, totalInvalid = 0, 0, 0, 0, 0
-    for _, r := range results {
-        if r == nil { continue }
-        if r.Valid { totalValid++ }
-        if r.Error == nil { totalSuccess++ } else {
-            switch r.Error.Error() {
-            case "execution reverted": totalRevert++
-            case "out of gas": totalOOG++
-            case "invalid transaction": totalInvalid++
-            }
-        }
-    }
+	// Aggregate stats from results
+	totalValid, totalSuccess, totalRevert, totalOOG, totalInvalid = 0, 0, 0, 0, 0
+	for _, r := range results {
+		if r == nil {
+			continue
+		}
+		if r.Valid {
+			totalValid++
+		}
+		if r.Error == nil {
+			totalSuccess++
+		} else {
+			switch r.Error.Error() {
+			case "execution reverted":
+				totalRevert++
+			case "out of gas":
+				totalOOG++
+			case "invalid transaction":
+				totalInvalid++
+			}
+		}
+	}
 
-    log.Debug("GPU transaction batch processed (scheduled)",
-        "batchSize", n,
-        "validTxs", totalValid,
-        "successTxs", totalSuccess,
-        "revertTxs", totalRevert,
-        "outOfGasTxs", totalOOG,
-        "invalidTxs", totalInvalid,
-        "gpuType", p.gpuType,
-        "kernelTargetMs", p.targetKernelMs,
-        "finalSliceSize", sliceSize,
-        "totalTime", time.Since(startBatch),
-    )
+	log.Debug("GPU transaction batch processed (scheduled)",
+		"batchSize", n,
+		"validTxs", totalValid,
+		"successTxs", totalSuccess,
+		"revertTxs", totalRevert,
+		"outOfGasTxs", totalOOG,
+		"invalidTxs", totalInvalid,
+		"gpuType", p.gpuType,
+		"kernelTargetMs", p.targetKernelMs,
+		"finalSliceSize", sliceSize,
+		"totalTime", time.Since(startBatch),
+	)
 }
 
-func min(a, b int) int { if a < b { return a } ; return b }
-func max(a, b int) int { if a > b { return a } ; return b }
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
 
 // processTransactionsCPU processes transactions using CPU as fallback
 func (p *GPUProcessor) processTransactionsCPU(batch *TransactionBatch) {
@@ -1489,7 +1585,7 @@ func (p *GPUProcessor) processTransactionsCPU(batch *TransactionBatch) {
 			Error:   nil,
 		}
 	}
-	
+
 	if batch.Callback != nil {
 		batch.Callback(batch.Results, nil)
 	}
@@ -1498,13 +1594,13 @@ func (p *GPUProcessor) processTransactionsCPU(batch *TransactionBatch) {
 // Helper functions for data preparation with safety checks
 func (p *GPUProcessor) prepareHashData(hashes [][]byte) []byte {
 	log.Trace("Starting hash data preparation", "hashCount", len(hashes))
-	
+
 	// OpenCL/CUDA kernels expect fixed 256 bytes per input item
 	const slot = 256
 	count := len(hashes)
 	total := count * slot
-	
-	log.Debug("Hash data preparation parameters", 
+
+	log.Debug("Hash data preparation parameters",
 		"slotSize", slot,
 		"hashCount", count,
 		"totalBufferSize", total,
@@ -1513,22 +1609,22 @@ func (p *GPUProcessor) prepareHashData(hashes [][]byte) []byte {
 	memStart := time.Now()
 	buf := p.memoryPool.Get().([]byte)
 	memGetTime := time.Since(memStart)
-	
-	log.Trace("Retrieved buffer from memory pool", 
+
+	log.Trace("Retrieved buffer from memory pool",
 		"bufferCapacity", cap(buf),
 		"requiredSize", total,
 		"memGetTime", memGetTime,
 	)
-	
+
 	if cap(buf) < total {
-		log.Debug("Memory pool buffer too small, allocating new buffer", 
+		log.Debug("Memory pool buffer too small, allocating new buffer",
 			"poolBufferCap", cap(buf),
 			"requiredSize", total,
 		)
 		allocStart := time.Now()
 		buf = make([]byte, total)
 		allocTime := time.Since(allocStart)
-		log.Debug("Allocated new hash buffer", 
+		log.Debug("Allocated new hash buffer",
 			"size", total,
 			"allocTime", allocTime,
 		)
@@ -1548,84 +1644,84 @@ func (p *GPUProcessor) prepareHashData(hashes [][]byte) []byte {
 		// Remaining bytes are already zeroed
 	}
 	copyTime := time.Since(copyStart)
-	
-	log.Debug("Hash data preparation completed", 
+
+	log.Debug("Hash data preparation completed",
 		"processedHashes", count,
 		"truncatedHashes", truncatedCount,
 		"finalBufferSize", len(data),
 		"copyTime", copyTime,
 		"totalPrepTime", time.Since(memStart),
 	)
-	
+
 	return data
 }
 
 func (p *GPUProcessor) prepareSignatureData(signatures, messages, publicKeys [][]byte) []byte {
 	log.Trace("Starting signature data preparation", "signatureCount", len(signatures))
-	
+
 	memStart := time.Now()
 	data := p.memoryPool.Get().([]byte)
 	memGetTime := time.Since(memStart)
-	
-	log.Debug("Retrieved signature buffer from memory pool", 
+
+	log.Debug("Retrieved signature buffer from memory pool",
 		"bufferSize", len(data),
 		"memGetTime", memGetTime,
 	)
-	
+
 	offset := 0
 	processedCount := 0
-	
+
 	copyStart := time.Now()
 	for i := range signatures {
 		totalSize := len(signatures[i]) + len(messages[i]) + len(publicKeys[i])
 		// Safety check to prevent buffer overflow
 		if offset+totalSize > len(data) {
-			log.Warn("Signature data buffer overflow, truncating batch", 
-				"offset", offset, 
-				"totalSize", totalSize, 
+			log.Warn("Signature data buffer overflow, truncating batch",
+				"offset", offset,
+				"totalSize", totalSize,
 				"bufferLen", len(data),
 				"processedItems", processedCount,
 				"remainingItems", len(signatures)-i,
 			)
 			break
 		}
-		
+
 		// Copy signature data
 		copy(data[offset:], signatures[i])
 		offset += len(signatures[i])
-		
+
 		// Copy message data
 		copy(data[offset:], messages[i])
 		offset += len(messages[i])
-		
+
 		// Copy public key data
 		copy(data[offset:], publicKeys[i])
 		offset += len(publicKeys[i])
-		
+
 		processedCount++
 	}
 	copyTime := time.Since(copyStart)
-	
-	log.Debug("Signature data preparation completed", 
+
+	log.Debug("Signature data preparation completed",
 		"requestedSignatures", len(signatures),
 		"processedSignatures", processedCount,
 		"finalBufferSize", offset,
 		"copyTime", copyTime,
 		"totalPrepTime", time.Since(memStart),
 	)
-	
+
 	return data[:offset]
 }
 
 func (p *GPUProcessor) prepareTransactionData(txs []*types.Transaction) []byte {
 	log.Trace("Starting transaction data preparation", "txCount", len(txs))
-	
+
 	// Kernels expect fixed 1024 bytes per transaction
 	const slot = 1024
 	count := len(txs)
 	total := count * slot
-	
-	log.Debug("Transaction data preparation parameters", 
+
+	log.Debug("Transaction data preparation parameters",
 		"slotSize", slot,
 		"txCount", count,
 		"totalBufferSize", total,
@@ -1634,22 +1730,22 @@ func (p *GPUProcessor) prepareTransactionData(txs []*types.Transaction) []byte {
 	memStart := time.Now()
 	buf := p.memoryPool.Get().([]byte)
 	memGetTime := time.Since(memStart)
-	
-	log.Trace("Retrieved transaction buffer from memory pool", 
+
+	log.Trace("Retrieved transaction buffer from memory pool",
 		"bufferCapacity", cap(buf),
 		"requiredSize", total,
 		"memGetTime", memGetTime,
 	)
-	
+
 	if cap(buf) < total {
-		log.Debug("Memory pool buffer too small, allocating new transaction buffer", 
+		log.Debug("Memory pool buffer too small, allocating new transaction buffer",
 			"poolBufferCap", cap(buf),
 			"requiredSize", total,
 		)
 		allocStart := time.Now()
 		buf = make([]byte, total)
 		allocTime := time.Since(allocStart)
-		log.Debug("Allocated new transaction buffer", 
+		log.Debug("Allocated new transaction buffer",
 			"size", total,
 			"allocTime", allocTime,
 		)
@@ -1660,19 +1756,19 @@ func (p *GPUProcessor) prepareTransactionData(txs []*types.Transaction) []byte {
 	marshalErrors := 0
 	truncatedCount := 0
 	totalMarshalledBytes := 0
-	
+
 	for i, tx := range txs {
 		txBytes, err := tx.MarshalBinary()
 		if err != nil {
-			log.Warn("Failed to marshal transaction", 
+			log.Warn("Failed to marshal transaction",
 				"txIndex", i,
-				"hash", tx.Hash(), 
+				"hash", tx.Hash(),
 				"error", err,
 			)
 			marshalErrors++
 			continue
 		}
-		
+
 		totalMarshalledBytes += len(txBytes)
 		base := i * slot
 		n := len(txBytes)
@@ -1680,7 +1776,7 @@ func (p *GPUProcessor) prepareTransactionData(txs []*types.Transaction) []byte {
 			// Truncate if too large for slot
 			n = slot
 			truncatedCount++
-			log.Trace("Transaction data truncated", 
+			log.Trace("Transaction data truncated",
 				"txIndex", i,
 				"originalSize", len(txBytes),
 				"truncatedSize", n,
@@ -1691,8 +1787,8 @@ func (p *GPUProcessor) prepareTransactionData(txs []*types.Transaction) []byte {
 		// Remaining bytes are left zeroed
 	}
 	marshalTime := time.Since(marshalStart)
-	
-	log.Debug("Transaction data preparation completed", 
+
+	log.Debug("Transaction data preparation completed",
 		"processedTxs", count,
 		"marshalErrors", marshalErrors,
 		"truncatedTxs", truncatedCount,
@@ -1701,190 +1797,190 @@ func (p *GPUProcessor) prepareTransactionData(txs []*types.Transaction) []byte {
 		"marshalTime", marshalTime,
 		"totalPrepTime", time.Since(memStart),
 	)
-	
+
 	return data
 }
 
 // prepareTransactionLengths returns the marshaled byte length of each tx (clamped to 1024)
 func (p *GPUProcessor) prepareTransactionLengths(txs []*types.Transaction) []int32 {
-    lengths := make([]int32, len(txs))
-    for i, tx := range txs {
-        b, err := tx.MarshalBinary()
-        if err != nil {
-            lengths[i] = 0
-            continue
-        }
-        if len(b) > 1024 {
-            lengths[i] = 1024
-        } else {
-            lengths[i] = int32(len(b))
-        }
-    }
-    return lengths
+	lengths := make([]int32, len(txs))
+	for i, tx := range txs {
+		b, err := tx.MarshalBinary()
+		if err != nil {
+			lengths[i] = 0
+			continue
+		}
+		if len(b) > 1024 {
+			lengths[i] = 1024
+		} else {
+			lengths[i] = int32(len(b))
+		}
+	}
+	return lengths
 }
 
 // verifyTxSignatureCPU performs canonical ECDSA recovery/verification on CPU
 func (p *GPUProcessor) verifyTxSignatureCPU(tx *types.Transaction) error {
-    // Choose permissive signer based on chain ID (handles typed txs)
-    chainID := tx.ChainId()
-    // Ensure non-nil
-    if chainID == nil {
-        chainID = new(big.Int)
-    }
-    signer := types.LatestSignerForChainID(chainID)
-    // Attempt to recover sender; error implies invalid signature
-    if _, err := types.Sender(signer, tx); err != nil {
-        return err
-    }
-    return nil
+	// Choose permissive signer based on chain ID (handles typed txs)
+	chainID := tx.ChainId()
+	// Ensure non-nil
+	if chainID == nil {
+		chainID = new(big.Int)
+	}
+	signer := types.LatestSignerForChainID(chainID)
+	// Attempt to recover sender; error implies invalid signature
+	if _, err := types.Sender(signer, tx); err != nil {
+		return err
+	}
+	return nil
 }
 
 // verifyBatchSignaturesCPU verifies a batch of transactions' signatures in parallel.
 func (p *GPUProcessor) verifyBatchSignaturesCPU(txs []*types.Transaction) []bool {
-    n := len(txs)
-    results := make([]bool, n)
-    if n == 0 {
-        return results
-    }
-    workers := p.configuredSigWorkers()
-    jobs := make(chan int, n)
-    var wg sync.WaitGroup
-    for w := 0; w < workers; w++ {
-        wg.Add(1)
-        go func() {
-            defer wg.Done()
-            for idx := range jobs {
-                tx := txs[idx]
-                err := p.verifyTxSignatureCPU(tx)
-                results[idx] = (err == nil)
-            }
-        }()
-    }
-    for i := 0; i < n; i++ {
-        jobs <- i
-    }
-    close(jobs)
-    wg.Wait()
-    return results
+	n := len(txs)
+	results := make([]bool, n)
+	if n == 0 {
+		return results
+	}
+	workers := p.configuredSigWorkers()
+	jobs := make(chan int, n)
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for idx := range jobs {
+				tx := txs[idx]
+				err := p.verifyTxSignatureCPU(tx)
+				results[idx] = (err == nil)
+			}
+		}()
+	}
+	for i := 0; i < n; i++ {
+		jobs <- i
+	}
+	close(jobs)
+	wg.Wait()
+	return results
 }
 
 // configuredSigWorkers picks an appropriate worker count for CPU signature verification.
 func (p *GPUProcessor) configuredSigWorkers() int {
-    // Default to SignatureWorkers if set; else use GOMAXPROCS.
-    workers := runtime.GOMAXPROCS(0)
-    // Try to read from GPUProcessor stats if available (SignatureWorkers exists in config defaults)
-    // Fallback to at least 4 workers
-    if workers < 4 {
-        workers = 4
-    }
-    return workers
+	// Default to SignatureWorkers if set; else use GOMAXPROCS.
+	workers := runtime.GOMAXPROCS(0)
+	// Try to read from GPUProcessor stats if available (SignatureWorkers exists in config defaults)
+	// Fallback to at least 4 workers
+	if workers < 4 {
+		workers = 4
+	}
+	return workers
 }
 
 // prepareSigningHashes computes the canonical signing-hash for each transaction
 // using the appropriate EIP-155/typed signer and returns a contiguous buffer
 // of 32-byte hashes plus an indexable view.
 func (p *GPUProcessor) prepareSigningHashes(txs []*types.Transaction) ([]byte, [][]byte) {
-    count := len(txs)
-    buf := make([]byte, count*32)
-    views := make([][]byte, count)
-    for i, tx := range txs {
-        chainID := tx.ChainId()
-        if chainID == nil {
-            chainID = new(big.Int)
-        }
-        signer := types.LatestSignerForChainID(chainID)
-        h := signer.Hash(tx)
-        off := i * 32
-        copy(buf[off:off+32], h[:])
-        views[i] = buf[off : off+32]
-    }
-    return buf, views
+	count := len(txs)
+	buf := make([]byte, count*32)
+	views := make([][]byte, count)
+	for i, tx := range txs {
+		chainID := tx.ChainId()
+		if chainID == nil {
+			chainID = new(big.Int)
+		}
+		signer := types.LatestSignerForChainID(chainID)
+		h := signer.Hash(tx)
+		off := i * 32
+		copy(buf[off:off+32], h[:])
+		views[i] = buf[off : off+32]
+	}
+	return buf, views
 }
 
 // verifyBatchECDSAWithSigningHash verifies signatures by recovering the pubkey
 // from the signing-hash returned in the GPU result buffer.
 func (p *GPUProcessor) verifyBatchECDSAWithSigningHash(txs []*types.Transaction, gpuOut []byte, count int) []bool {
-    results := make([]bool, count)
-    workers := p.configuredSigWorkers()
-    jobs := make(chan int, count)
-    var wg sync.WaitGroup
-    for w := 0; w < workers; w++ {
-        wg.Add(1)
-        go func() {
-            defer wg.Done()
-            for i := range jobs {
-                tx := txs[i]
-                // Extract signing-hash from GPU result
-                base := i*160 + 106
-                if base+32 > len(gpuOut) {
-                    results[i] = false
-                    continue
-                }
-                msg := gpuOut[base : base+32]
-                sig, err := buildRecoverySignature(tx)
-                if err != nil {
-                    results[i] = false
-                    continue
-                }
-                if _, err := crypto.SigToPub(msg, sig); err != nil {
-                    results[i] = false
-                } else {
-                    results[i] = true
-                }
-            }
-        }()
-    }
-    for i := 0; i < count; i++ {
-        jobs <- i
-    }
-    close(jobs)
-    wg.Wait()
-    return results
+	results := make([]bool, count)
+	workers := p.configuredSigWorkers()
+	jobs := make(chan int, count)
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := range jobs {
+				tx := txs[i]
+				// Extract signing-hash from GPU result
+				base := i*160 + 106
+				if base+32 > len(gpuOut) {
+					results[i] = false
+					continue
+				}
+				msg := gpuOut[base : base+32]
+				sig, err := buildRecoverySignature(tx)
+				if err != nil {
+					results[i] = false
+					continue
+				}
+				if _, err := crypto.SigToPub(msg, sig); err != nil {
+					results[i] = false
+				} else {
+					results[i] = true
+				}
+			}
+		}()
+	}
+	for i := 0; i < count; i++ {
+		jobs <- i
+	}
+	close(jobs)
+	wg.Wait()
+	return results
 }
 
 // buildRecoverySignature constructs a 65-byte signature (R||S||Vparity) with V as 0/1
 // suitable for crypto.SigToPub from a tx's raw signature values.
 func buildRecoverySignature(tx *types.Transaction) ([]byte, error) {
-    v, r, s := tx.RawSignatureValues()
-    if v == nil || r == nil || s == nil {
-        return nil, errors.New("missing signature values")
-    }
-    sig := make([]byte, 65)
-    rb := r.Bytes()
-    sb := s.Bytes()
-    if len(rb) > 32 || len(sb) > 32 {
-        return nil, errors.New("invalid r/s length")
-    }
-    copy(sig[32-len(rb):32], rb)
-    copy(sig[64-len(sb):64], sb)
-    // Compute y-parity
-    var parity byte
-    if tx.Type() == 1 || tx.Type() == 2 {
-        parity = byte(new(big.Int).And(v, big.NewInt(1)).Uint64())
-    } else {
-        v64 := v.Uint64()
-        if v64 == 27 || v64 == 28 {
-            parity = byte(v64 - 27)
-        } else if v64 >= 35 {
-            parity = byte((v64 - 35) % 2)
-        } else {
-            parity = byte(v64 % 2)
-        }
-    }
-    sig[64] = parity // SigToPub expects 0/1 here
-    return sig, nil
+	v, r, s := tx.RawSignatureValues()
+	if v == nil || r == nil || s == nil {
+		return nil, errors.New("missing signature values")
+	}
+	sig := make([]byte, 65)
+	rb := r.Bytes()
+	sb := s.Bytes()
+	if len(rb) > 32 || len(sb) > 32 {
+		return nil, errors.New("invalid r/s length")
+	}
+	copy(sig[32-len(rb):32], rb)
+	copy(sig[64-len(sb):64], sb)
+	// Compute y-parity
+	var parity byte
+	if tx.Type() == 1 || tx.Type() == 2 {
+		parity = byte(new(big.Int).And(v, big.NewInt(1)).Uint64())
+	} else {
+		v64 := v.Uint64()
+		if v64 == 27 || v64 == 28 {
+			parity = byte(v64 - 27)
+		} else if v64 >= 35 {
+			parity = byte((v64 - 35) % 2)
+		} else {
+			parity = byte(v64 % 2)
+		}
+	}
+	sig[64] = parity // SigToPub expects 0/1 here
+	return sig, nil
 }
 
 // prepareStateSnapshots prepares state snapshot data for GPU processing
 func (p *GPUProcessor) prepareStateSnapshots(txs []*types.Transaction) []byte {
 	log.Trace("Starting state snapshot preparation", "txCount", len(txs))
-	
+
 	// Kernels expect fixed 2048 bytes per transaction for state data
 	const slot = 2048
 	count := len(txs)
 	total := count * slot
-	
-	log.Debug("State snapshot preparation parameters", 
+
+	log.Debug("State snapshot preparation parameters",
 		"slotSize", slot,
 		"txCount", count,
 		"totalBufferSize", total,
@@ -1893,22 +1989,22 @@ func (p *GPUProcessor) prepareStateSnapshots(txs []*types.Transaction) []byte {
 	memStart := time.Now()
 	buf := p.memoryPool.Get().([]byte)
 	memGetTime := time.Since(memStart)
-	
-	log.Trace("Retrieved state buffer from memory pool", 
+
+	log.Trace("Retrieved state buffer from memory pool",
 		"bufferCapacity", cap(buf),
 		"requiredSize", total,
 		"memGetTime", memGetTime,
 	)
-	
+
 	if cap(buf) < total {
-		log.Debug("Memory pool buffer too small, allocating new state buffer", 
+		log.Debug("Memory pool buffer too small, allocating new state buffer",
 			"poolBufferCap", cap(buf),
 			"requiredSize", total,
 		)
 		allocStart := time.Now()
 		buf = make([]byte, total)
 		allocTime := time.Since(allocStart)
-		log.Debug("Allocated new state buffer", 
+		log.Debug("Allocated new state buffer",
 			"size", total,
 			"allocTime", allocTime,
 		)
@@ -1921,14 +2017,14 @@ func (p *GPUProcessor) prepareStateSnapshots(txs []*types.Transaction) []byte {
 	// - Contract storage states
 	// - Code hashes
 	// - State root information
-	
+
 	prepStart := time.Now()
 	for i, tx := range txs {
 		base := i * slot
-		
+
 		// Simplified state snapshot structure:
 		// [0-31]: sender address (20 bytes + 12 padding)
-		// [32-63]: recipient address (20 bytes + 12 padding) 
+		// [32-63]: recipient address (20 bytes + 12 padding)
 		// [64-95]: sender balance (32 bytes)
 		// [96-127]: sender nonce (32 bytes)
 		// [128-159]: recipient balance (32 bytes)
@@ -1936,13 +2032,13 @@ func (p *GPUProcessor) prepareStateSnapshots(txs []*types.Transaction) []byte {
 		// [192-223]: block number (32 bytes)
 		// [224-255]: block timestamp (32 bytes)
 		// [256-2047]: reserved for contract storage/code
-		
+
 		// Extract sender address (simplified - would need proper state access)
 		if tx.To() != nil {
 			// Copy recipient address
 			copy(data[base+32:base+52], tx.To().Bytes())
 		}
-		
+
 		// Set simplified values (in production, these would come from state DB)
 		// Gas price
 		gasPrice := tx.GasPrice()
@@ -1952,7 +2048,7 @@ func (p *GPUProcessor) prepareStateSnapshots(txs []*types.Transaction) []byte {
 				copy(data[base+160+32-len(gasPriceBytes):base+192], gasPriceBytes)
 			}
 		}
-		
+
 		// Transaction value
 		value := tx.Value()
 		if value != nil {
@@ -1961,33 +2057,33 @@ func (p *GPUProcessor) prepareStateSnapshots(txs []*types.Transaction) []byte {
 				copy(data[base+64+32-len(valueBytes):base+96], valueBytes)
 			}
 		}
-		
+
 		// Nonce
 		nonce := tx.Nonce()
 		binary.BigEndian.PutUint64(data[base+96+24:base+104], nonce)
 	}
 	prepTime := time.Since(prepStart)
-	
-	log.Debug("State snapshot preparation completed", 
+
+	log.Debug("State snapshot preparation completed",
 		"processedTxs", count,
 		"finalBufferSize", len(data),
 		"prepTime", prepTime,
 		"totalPrepTime", time.Since(memStart),
 	)
-	
+
 	return data
 }
 
 // prepareAccessLists prepares access list data for GPU processing
 func (p *GPUProcessor) prepareAccessLists(txs []*types.Transaction) []byte {
 	log.Trace("Starting access list preparation", "txCount", len(txs))
-	
+
 	// Kernels expect fixed 512 bytes per transaction for access lists
 	const slot = 512
 	count := len(txs)
 	total := count * slot
-	
-	log.Debug("Access list preparation parameters", 
+
+	log.Debug("Access list preparation parameters",
 		"slotSize", slot,
 		"txCount", count,
 		"totalBufferSize", total,
@@ -1996,22 +2092,22 @@ func (p *GPUProcessor) prepareAccessLists(txs []*types.Transaction) []byte {
 	memStart := time.Now()
 	buf := p.memoryPool.Get().([]byte)
 	memGetTime := time.Since(memStart)
-	
-	log.Trace("Retrieved access list buffer from memory pool", 
+
+	log.Trace("Retrieved access list buffer from memory pool",
 		"bufferCapacity", cap(buf),
 		"requiredSize", total,
 		"memGetTime", memGetTime,
 	)
-	
+
 	if cap(buf) < total {
-		log.Debug("Memory pool buffer too small, allocating new access list buffer", 
+		log.Debug("Memory pool buffer too small, allocating new access list buffer",
 			"poolBufferCap", cap(buf),
 			"requiredSize", total,
 		)
 		allocStart := time.Now()
 		buf = make([]byte, total)
 		allocTime := time.Since(allocStart)
-		log.Debug("Allocated new access list buffer", 
+		log.Debug("Allocated new access list buffer",
 			"size", total,
 			"allocTime", allocTime,
 		)
@@ -2020,29 +2116,29 @@ func (p *GPUProcessor) prepareAccessLists(txs []*types.Transaction) []byte {
 
 	prepStart := time.Now()
 	accessListCount := 0
-	
+
 	for i, tx := range txs {
 		base := i * slot
 		offset := 0
-		
+
 		// Get access list from transaction
 		accessList := tx.AccessList()
 		if len(accessList) > 0 {
 			accessListCount++
-			
+
 			// Access list structure:
 			// [0-1]: number of addresses (2 bytes)
 			// [2-3]: total storage keys (2 bytes)
 			// [4+]: address entries, each followed by storage keys
 			//   - Address: 20 bytes
-			//   - Storage key count: 2 bytes  
+			//   - Storage key count: 2 bytes
 			//   - Storage keys: 32 bytes each
-			
+
 			if offset+4 < slot {
 				// Write number of addresses
 				binary.LittleEndian.PutUint16(data[base+offset:base+offset+2], uint16(len(accessList)))
 				offset += 2
-				
+
 				// Count total storage keys
 				totalKeys := 0
 				for _, entry := range accessList {
@@ -2050,7 +2146,7 @@ func (p *GPUProcessor) prepareAccessLists(txs []*types.Transaction) []byte {
 				}
 				binary.LittleEndian.PutUint16(data[base+offset:base+offset+2], uint16(totalKeys))
 				offset += 2
-				
+
 				// Write access list entries
 				for _, entry := range accessList {
 					// Write address (20 bytes)
@@ -2060,7 +2156,7 @@ func (p *GPUProcessor) prepareAccessLists(txs []*types.Transaction) []byte {
 					} else {
 						break
 					}
-					
+
 					// Write storage key count (2 bytes)
 					if offset+2 < slot {
 						binary.LittleEndian.PutUint16(data[base+offset:base+offset+2], uint16(len(entry.StorageKeys)))
@@ -2068,7 +2164,7 @@ func (p *GPUProcessor) prepareAccessLists(txs []*types.Transaction) []byte {
 					} else {
 						break
 					}
-					
+
 					// Write storage keys (32 bytes each)
 					for _, key := range entry.StorageKeys {
 						if offset+32 < slot {
@@ -2078,7 +2174,7 @@ func (p *GPUProcessor) prepareAccessLists(txs []*types.Transaction) []byte {
 							break
 						}
 					}
-					
+
 					if offset >= slot-64 { // Leave some buffer space
 						break
 					}
@@ -2088,15 +2184,15 @@ func (p *GPUProcessor) prepareAccessLists(txs []*types.Transaction) []byte {
 		// If no access list, the slot remains zeroed
 	}
 	prepTime := time.Since(prepStart)
-	
-	log.Debug("Access list preparation completed", 
+
+	log.Debug("Access list preparation completed",
 		"processedTxs", count,
 		"txsWithAccessLists", accessListCount,
 		"finalBufferSize", len(data),
 		"prepTime", prepTime,
 		"totalPrepTime", time.Since(memStart),
 	)
-	
+
 	return data
 }
 
@@ -2122,7 +2218,7 @@ func (p *GPUProcessor) convertTransactionResults(batch *TransactionBatch) {
 func (p *GPUProcessor) updateHashStats(duration time.Duration) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	
+
 	p.processedHashes++
 	if p.avgHashTime == 0 {
 		p.avgHashTime = duration
@@ -2134,7 +2230,7 @@ func (p *GPUProcessor) updateHashStats(duration time.Duration) {
 func (p *GPUProcessor) updateSigStats(duration time.Duration) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	
+
 	p.processedSigs++
 	if p.avgSigTime == 0 {
 		p.avgSigTime = duration
@@ -2146,17 +2242,17 @@ func (p *GPUProcessor) updateSigStats(duration time.Duration) {
 func (p *GPUProcessor) updateTxStats(duration time.Duration) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	
+
 	p.processedTxs++
 	if p.avgTxTime == 0 {
 		p.avgTxTime = duration
 	} else {
 		p.avgTxTime = (p.avgTxTime + duration) / 2
 	}
-	
+
 	// Log cumulative GPU statistics every 1000 transactions
 	if p.processedTxs%1000 == 0 {
-		log.Info("📊 GPU CUMULATIVE STATISTICS", 
+		log.Info("📊 GPU CUMULATIVE STATISTICS",
 			"totalTransactionsProcessed", p.processedTxs,
 			"totalHashesProcessed", p.processedHashes,
 			"totalSignaturesProcessed", p.processedSigs,
@@ -2174,7 +2270,7 @@ func (p *GPUProcessor) updateTxStats(duration time.Duration) {
 func (p *GPUProcessor) GetStats() GPUStats {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
-	
+
 	return GPUStats{
 		GPUType:         p.gpuType,
 		DeviceCount:     p.deviceCount,
@@ -2215,16 +2311,21 @@ func (p *GPUProcessor) GetGPUType() GPUType {
 	return p.gpuType
 }
 
+// GetDeviceCount returns the number of detected GPU devices.
+func (p *GPUProcessor) GetDeviceCount() int {
+	return p.deviceCount
+}
+
 // Close gracefully shuts down the GPU processor
 func (p *GPUProcessor) Close() error {
 	log.Info("Shutting down GPU processor...")
-	
+
 	// Cancel context to stop all workers
 	p.cancel()
-	
+
 	// Wait for all workers to finish
 	p.wg.Wait()
-	
+
 	// Cleanup GPU resources
 	switch p.gpuType {
 	case GPUTypeCUDA:
@@ -2232,7 +2333,7 @@ func (p *GPUProcessor) Close() error {
 	case GPUTypeOpenCL:
 		C.cleanupOpenCL()
 	}
-	
+
 	log.Info("GPU processor shutdown complete")
 	return nil
 }
@@ -2245,7 +2346,7 @@ func InitGlobalGPUProcessor(config *GPUConfig) error {
 	if globalGPUProcessor != nil {
 		globalGPUProcessor.Close()
 	}
-	
+
 	var err error
 	globalGPUProcessor, err = NewGPUProcessor(config)
 	return err

--- a/Core-Blockchain/node_src/common/hybrid/hybrid_processor.go
+++ b/Core-Blockchain/node_src/common/hybrid/hybrid_processor.go
@@ -171,6 +171,15 @@ type HybridStats struct {
 	GPUMemoryUsage     uint64        `json:"gpuMemoryUsage"`
 }
 
+// GPUStatus describes the availability of GPU acceleration from the hybrid processor.
+type GPUStatus struct {
+	ConfigEnabled     bool        `json:"configEnabled"`
+	Available         bool        `json:"available"`
+	Type              gpu.GPUType `json:"type"`
+	DeviceCount       int         `json:"deviceCount"`
+	UnavailableReason string      `json:"unavailableReason,omitempty"`
+}
+
 // NewHybridProcessor creates a new hybrid processor
 func NewHybridProcessor(config *HybridConfig) (*HybridProcessor, error) {
 	if config == nil {
@@ -363,7 +372,7 @@ func (h *HybridProcessor) recordStrategyDecision(strategy ProcessingStrategy, ba
 			"gpuUtil", gpuUtil,
 			"adaptiveRatio", adaptiveRatio,
 		)
-		
+
 		// Log strategy changes to file
 		logging.LogHybrid("INFO", "HYBRID STRATEGY CHANGE",
 			"from", previousStrategy.String(),
@@ -712,9 +721,9 @@ func (h *HybridProcessor) updateStats(cpuProcessed, gpuProcessed uint64, duratio
 
 	if shouldWarn {
 		log.Warn("Hybrid throughput below target", "strategy", strategy.String(), "tps", currentTPS, "target", h.config.ThroughputTarget, "avgLatency", avgLatency, "cpuProcessed", cpuProcessed, "gpuProcessed", gpuProcessed, "duration", duration, "loadRatio", loadRatio)
-		
+
 		// Log performance warnings to file
-		logging.LogPerformance("WARN", "HYBRID THROUGHPUT BELOW TARGET", 
+		logging.LogPerformance("WARN", "HYBRID THROUGHPUT BELOW TARGET",
 			"strategy", strategy.String(),
 			"currentTPS", currentTPS,
 			"targetTPS", h.config.ThroughputTarget,
@@ -728,9 +737,9 @@ func (h *HybridProcessor) updateStats(cpuProcessed, gpuProcessed uint64, duratio
 
 	if shouldCheer {
 		log.Info("Hybrid throughput met target", "strategy", strategy.String(), "tps", currentTPS, "target", h.config.ThroughputTarget, "avgLatency", avgLatency, "cpuProcessed", cpuProcessed, "gpuProcessed", gpuProcessed, "duration", duration, "loadRatio", loadRatio)
-		
+
 		// Log performance successes to file
-		logging.LogPerformance("INFO", "HYBRID THROUGHPUT TARGET ACHIEVED", 
+		logging.LogPerformance("INFO", "HYBRID THROUGHPUT TARGET ACHIEVED",
 			"strategy", strategy.String(),
 			"currentTPS", currentTPS,
 			"targetTPS", h.config.ThroughputTarget,
@@ -1019,6 +1028,40 @@ func (h *HybridProcessor) GetStats() HybridStats {
 	defer h.mu.RUnlock()
 
 	return h.stats
+}
+
+// GetGPUStatus exposes the current GPU availability and configuration state.
+func (h *HybridProcessor) GetGPUStatus() GPUStatus {
+	status := GPUStatus{}
+
+	if h == nil {
+		status.UnavailableReason = "hybrid_processor_nil"
+		return status
+	}
+
+	if h.config != nil {
+		status.ConfigEnabled = h.config.EnableGPU
+	}
+
+	if !status.ConfigEnabled {
+		status.UnavailableReason = "disabled_in_config"
+		return status
+	}
+
+	if h.gpuProcessor == nil {
+		status.UnavailableReason = "not_initialized"
+		return status
+	}
+
+	status.Type = h.gpuProcessor.GetGPUType()
+	status.DeviceCount = h.gpuProcessor.GetDeviceCount()
+	status.Available = h.gpuProcessor.IsGPUAvailable() && status.DeviceCount > 0
+
+	if !status.Available {
+		status.UnavailableReason = "no_device_detected"
+	}
+
+	return status
 }
 
 // Close gracefully shuts down the hybrid processor


### PR DESCRIPTION
## Summary
- add stringification and device count accessor for GPU processors so status logs are meaningful
- expose GPUStatus information from the hybrid processor to report configuration, availability, and detected devices
- update the miner worker to log GPU availability, warn when the GPU pipeline is inactive, and include GPU status in miner stats

## Testing
- `go test ./...` *(fails: import cycle in github.com/ethereum/go-ethereum/signer/core/apitypes tests)*

------
https://chatgpt.com/codex/tasks/task_e_68cd3bb82650832488c14d0f18cd1b51