### PR TITLE
Improve GPU activity diagnostics and logging

### DIFF
--- a/Core-Blockchain/node_src/miner/miner.go
+++ b/Core-Blockchain/node_src/miner/miner.go
@@ -44,15 +44,16 @@ type Backend interface {
 
 // Config is the configuration parameters of mining.
 type Config struct {
-	Etherbase  common.Address `toml:",omitempty"` // Public address for block mining rewards (default = first account)
-	Notify     []string       `toml:",omitempty"` // HTTP URL list to be notified of new work packages (only useful in ethash).
-	NotifyFull bool           `toml:",omitempty"` // Notify with pending block headers instead of work packages
-	ExtraData  hexutil.Bytes  `toml:",omitempty"` // Block extra data set by the miner
-	GasFloor   uint64         // Target gas floor for mined blocks.
-	GasCeil    uint64         // Target gas ceiling for mined blocks.
-	GasPrice   *big.Int       // Minimum gas price for mining a transaction
-	Recommit   time.Duration  // The time interval for miner to re-create mining work.
-	Noverify   bool           // Disable remote mining solution verification(only useful in ethash).
+	Etherbase            common.Address `toml:",omitempty"` // Public address for block mining rewards (default = first account)
+	Notify               []string       `toml:",omitempty"` // HTTP URL list to be notified of new work packages (only useful in ethash).
+	NotifyFull           bool           `toml:",omitempty"` // Notify with pending block headers instead of work packages
+	ExtraData            hexutil.Bytes  `toml:",omitempty"` // Block extra data set by the miner
+	GasFloor             uint64         // Target gas floor for mined blocks.
+	GasCeil              uint64         // Target gas ceiling for mined blocks.
+	GasPrice             *big.Int       // Minimum gas price for mining a transaction
+	Recommit             time.Duration  // The time interval for miner to re-create mining work.
+	Noverify             bool           // Disable remote mining solution verification(only useful in ethash).
+	EnableGPUDiagnostics bool           `toml:",omitempty"` // Enable verbose GPU batch diagnostics logging
 }
 
 // Miner creates blocks and searches for proof-of-work values.

--- a/Core-Blockchain/node_src/miner/worker.go
+++ b/Core-Blockchain/node_src/miner/worker.go
@@ -185,17 +185,25 @@ type worker struct {
 	isPoSA bool
 
 	// GPU/Hybrid processing integration
-	hybridProcessor   *hybrid.HybridProcessor
-	parallelProcessor *core.ParallelStateProcessor
-	aiLoadBalancer    *ai.AILoadBalancer
-	gpuEnabled        bool
-	batchThreshold    int
-	lastBatchSize     int
-	lastBatchTime     time.Duration
-	lastDispatchTime  time.Duration
-	lastExecutorTime  time.Duration
-	adaptiveBatching  bool
-	aiOptimization    bool
+	hybridProcessor        *hybrid.HybridProcessor
+	parallelProcessor      *core.ParallelStateProcessor
+	aiLoadBalancer         *ai.AILoadBalancer
+	gpuEnabled             bool
+	batchThreshold         int
+	lastBatchSize          int
+	lastBatchTime          time.Duration
+	lastDispatchTime       time.Duration
+	lastExecutorTime       time.Duration
+	lastGPUStatusLog       time.Time
+	lastGPUSummaryLog      time.Time
+	gpuDiagnostics         bool
+	adaptiveBatching       bool
+	aiOptimization         bool
+	gpuSummaryInterval     time.Duration
+	gpuSummaryBatches      int
+	gpuSummaryTransactions int
+	gpuSummaryDuration     time.Duration
+	gpuPipelineActive      bool
 
 	// Feeds
 	pendingLogsFeed event.Feed
@@ -258,6 +266,18 @@ type worker struct {
 	resubmitHook func(time.Duration, time.Duration) // Method to call upon updating resubmitting interval.
 }
 
+func (w *worker) gpuLogInfo(msg string, ctx ...interface{}) {
+	if w.gpuDiagnostics {
+		log.Info(msg, ctx...)
+	}
+}
+
+func (w *worker) gpuLogDebug(msg string, ctx ...interface{}) {
+	if w.gpuDiagnostics {
+		log.Debug(msg, ctx...)
+	}
+}
+
 func newWorker(config *Config, chainConfig *params.ChainConfig, engine consensus.Engine, eth Backend, mux *event.TypeMux, isLocalBlock func(*types.Block) bool, init bool) *worker {
 	posa, isPoSA := engine.(consensus.PoSA)
 	worker := &worker{
@@ -287,16 +307,29 @@ func newWorker(config *Config, chainConfig *params.ChainConfig, engine consensus
 		batchThreshold:     50000, // 50K threshold for GPU activation - 5x increase for 200K+ TPS
 		adaptiveBatching:   true,  // Enable adaptive batch sizing for 1M+ transactions
 		aiOptimization:     true,  // Enable AI-driven optimization
+		gpuSummaryInterval: 5 * time.Second,
+	}
+
+	if config != nil {
+		worker.gpuDiagnostics = config.EnableGPUDiagnostics
 	}
 
 	// Initialize hybrid processor for GPU acceleration
 	hybridProcessor := hybrid.GetGlobalHybridProcessor()
 	if hybridProcessor != nil {
 		worker.hybridProcessor = hybridProcessor
-		// Check if GPU is enabled by looking at the hybrid processor's configuration
-		stats := hybridProcessor.GetStats()
-		worker.gpuEnabled = stats.GPUProcessed > 0 || stats.GPUUtilization >= 0
-		log.Info("Miner GPU acceleration initialized", "enabled", worker.gpuEnabled)
+		status := hybridProcessor.GetGPUStatus()
+		worker.gpuEnabled = status.ConfigEnabled && status.Available
+		log.Info("Miner GPU acceleration initialized",
+			"enabled", worker.gpuEnabled,
+			"configured", status.ConfigEnabled,
+			"available", status.Available,
+			"type", status.Type.String(),
+			"devices", status.DeviceCount,
+		)
+		if !worker.gpuEnabled && status.UnavailableReason != "" {
+			log.Warn("GPU acceleration inactive", "reason", status.UnavailableReason)
+		}
 	} else {
 		log.Info("Miner running in CPU-only mode")
 	}
@@ -314,7 +347,7 @@ func newWorker(config *Config, chainConfig *params.ChainConfig, engine consensus
 	// Initialize parallel state processor for advanced parallel processing
 	parallelConfig := core.DefaultParallelProcessorConfig()
 	// Optimize for i5-13500 (14 cores, 20 threads) + RTX 4000 SFF Ada
-    // Align with GPU-first plan while reserving capacity for MobileLLM-R1-950M
+	// Align with GPU-first plan while reserving capacity for MobileLLM-R1-950M
 	cpuCores := runtime.NumCPU()                           // 20 threads
 	parallelConfig.TxBatchSize = 100000                    // Match GPU-validated batches (100K transactions)
 	parallelConfig.MaxTxConcurrency = cpuCores * 12        // Use ~75% of CPU cores for blockchain execution
@@ -327,7 +360,7 @@ func newWorker(config *Config, chainConfig *params.ChainConfig, engine consensus
 		"cpuCores", cpuCores,
 		"maxConcurrency", parallelConfig.MaxTxConcurrency,
 		"maxGoroutines", parallelConfig.MaxGoroutines,
-            "reservedForAI", "25% CPU + 2GB GPU for MobileLLM")
+		"reservedForAI", "25% CPU + 2GB GPU for MobileLLM")
 
 	var err error
 	worker.parallelProcessor, err = core.NewParallelStateProcessor(chainConfig, eth.BlockChain(), engine, parallelConfig)
@@ -1092,12 +1125,150 @@ func (w *worker) recordGPUExecutorDiagnostics(batchNumber int, applied int, disp
 	w.lastExecutorTime = executorTime
 	w.mu.Unlock()
 
-	log.Info("GPU batch CPU executor diagnostics",
+	w.gpuLogInfo("GPU batch CPU executor diagnostics",
 		"batchNumber", batchNumber,
 		"appliedTxs", applied,
 		"mainThreadDispatch", dispatchTime,
 		"executorRuntime", executorTime,
 		"mainThreadSavings", savings,
+	)
+}
+
+func (w *worker) emitGPUSummary(status hybrid.GPUStatus, trigger string, batches int, transactions int, totalDuration time.Duration) {
+	if batches == 0 && transactions == 0 {
+		return
+	}
+
+	avgDuration := time.Duration(0)
+	if batches > 0 {
+		avgDuration = totalDuration / time.Duration(batches)
+	}
+
+	log.Info("GPU activity summary",
+		"trigger", trigger,
+		"batches", batches,
+		"transactions", transactions,
+		"avgBatchDuration", avgDuration,
+		"lastBatchAt", status.LastBatchAt,
+		"lastBatchCount", status.LastBatchCount,
+		"lastBatchDuration", status.LastBatchDuration,
+		"totalBatches", status.TotalBatches,
+		"totalTransactions", status.TotalTransactions,
+		"lastFailure", status.LastFailure,
+		"lastFailureAt", status.LastFailureAt,
+		"gpuType", status.Type.String(),
+		"devices", status.DeviceCount,
+	)
+}
+
+func (w *worker) flushGPUSummary(trigger string) {
+	w.mu.Lock()
+	batches := w.gpuSummaryBatches
+	transactions := w.gpuSummaryTransactions
+	totalDuration := w.gpuSummaryDuration
+	w.gpuSummaryBatches = 0
+	w.gpuSummaryTransactions = 0
+	w.gpuSummaryDuration = 0
+	w.lastGPUSummaryLog = time.Now()
+	w.mu.Unlock()
+
+	if w.hybridProcessor == nil {
+		return
+	}
+
+	status := w.hybridProcessor.GetGPUStatus()
+	w.emitGPUSummary(status, trigger, batches, transactions, totalDuration)
+}
+
+func (w *worker) recordGPUBatchSuccess(applied int, duration time.Duration) {
+	if w.hybridProcessor == nil {
+		return
+	}
+
+	status := w.hybridProcessor.GetGPUStatus()
+	now := time.Now()
+
+	var logActivation bool
+	var shouldLogSummary bool
+	var summaryBatches int
+	var summaryTransactions int
+	var summaryDuration time.Duration
+
+	w.mu.Lock()
+	if w.gpuSummaryInterval <= 0 {
+		w.gpuSummaryInterval = 5 * time.Second
+	}
+	if !w.gpuPipelineActive {
+		w.gpuPipelineActive = true
+		w.lastGPUSummaryLog = now
+		w.gpuSummaryBatches = 0
+		w.gpuSummaryTransactions = 0
+		w.gpuSummaryDuration = 0
+		logActivation = true
+	}
+
+	w.gpuSummaryBatches++
+	w.gpuSummaryTransactions += applied
+	w.gpuSummaryDuration += duration
+
+	if now.Sub(w.lastGPUSummaryLog) >= w.gpuSummaryInterval {
+		shouldLogSummary = true
+		summaryBatches = w.gpuSummaryBatches
+		summaryTransactions = w.gpuSummaryTransactions
+		summaryDuration = w.gpuSummaryDuration
+		w.gpuSummaryBatches = 0
+		w.gpuSummaryTransactions = 0
+		w.gpuSummaryDuration = 0
+		w.lastGPUSummaryLog = now
+	}
+	w.mu.Unlock()
+
+	if logActivation {
+		log.Info("GPU pipeline activated",
+			"gpuType", status.Type.String(),
+			"devices", status.DeviceCount,
+			"lastBatchAt", status.LastBatchAt,
+			"totalBatches", status.TotalBatches,
+			"totalTransactions", status.TotalTransactions,
+		)
+	}
+
+	if shouldLogSummary {
+		w.emitGPUSummary(status, "interval", summaryBatches, summaryTransactions, summaryDuration)
+	}
+}
+
+func (w *worker) maybeLogGPUInactive(reason string) {
+	const statusLogInterval = 10 * time.Second
+
+	now := time.Now()
+	w.mu.Lock()
+	if !w.lastGPUStatusLog.IsZero() && now.Sub(w.lastGPUStatusLog) < statusLogInterval {
+		w.mu.Unlock()
+		return
+	}
+	w.lastGPUStatusLog = now
+	shouldFlush := w.gpuSummaryBatches > 0 || w.gpuSummaryTransactions > 0 || w.gpuPipelineActive
+	w.gpuPipelineActive = false
+	w.mu.Unlock()
+
+	if shouldFlush {
+		w.flushGPUSummary("inactive")
+	}
+
+	if w.hybridProcessor == nil {
+		log.Warn("GPU pipeline inactive", "reason", reason, "hybridProcessor", "nil")
+		return
+	}
+
+	status := w.hybridProcessor.GetGPUStatus()
+	log.Warn("GPU pipeline inactive",
+		"reason", reason,
+		"configured", status.ConfigEnabled,
+		"available", status.Available,
+		"type", status.Type.String(),
+		"devices", status.DeviceCount,
+		"detail", status.UnavailableReason,
 	)
 }
 
@@ -1125,7 +1296,8 @@ func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coin
 		for {
 			// Check if we have enough gas and transactions for another GPU batch
 			if w.current.gasPool.Gas() < params.TxGas {
-				log.Debug("Insufficient gas for more GPU batches", "remaining", w.current.gasPool.Gas())
+				w.gpuLogDebug("Insufficient gas for more GPU batches", "remaining", w.current.gasPool.Gas())
+				w.maybeLogGPUInactive("gpu_insufficient_gas")
 				break
 			}
 
@@ -1158,13 +1330,14 @@ func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coin
 
 			// Break if we don't have enough transactions for a meaningful GPU batch
 			if len(txBatch) < w.batchThreshold/10 { // Minimum 5K transactions for GPU batch (50K/10)
-				log.Debug("Insufficient transactions for GPU batch", "available", len(txBatch), "minimum", w.batchThreshold/10)
+				w.gpuLogDebug("Insufficient transactions for GPU batch", "available", len(txBatch), "minimum", w.batchThreshold/10)
+				w.maybeLogGPUInactive("gpu_batch_too_small")
 				break
 			}
 
 			// Process batch with GPU
 			batchStart := time.Now()
-			log.Info("Processing GPU batch", "batchNumber", batchNumber, "batchSize", len(txBatch), "totalProcessed", totalGPUProcessed)
+			w.gpuLogInfo("Processing GPU batch", "batchNumber", batchNumber, "batchSize", len(txBatch), "totalProcessed", totalGPUProcessed)
 
 			// Use hybrid processor for GPU-accelerated prevalidation
 			appliedCount := 0
@@ -1173,6 +1346,7 @@ func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coin
 				if err != nil {
 					batchApplyErr = err
 					log.Warn("GPU batch processing failed, falling back to sequential", "batchNumber", batchNumber, "error", err)
+					w.maybeLogGPUInactive("hybrid_batch_error")
 					return
 				}
 
@@ -1186,7 +1360,7 @@ func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coin
 				dispatchDuration := time.Since(callbackStart)
 
 				if len(validated) == 0 {
-					log.Debug("GPU batch returned no validated transactions", "batchNumber", batchNumber)
+					w.gpuLogDebug("GPU batch returned no validated transactions", "batchNumber", batchNumber)
 					return
 				}
 
@@ -1211,6 +1385,7 @@ func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coin
 				if applyErr != nil {
 					batchApplyErr = applyErr
 					log.Warn("Parallel executor failed to apply GPU validated transactions", "batchNumber", batchNumber, "error", applyErr, "dispatchTime", dispatchDuration, "executorTime", executorTime)
+					w.maybeLogGPUInactive("gpu_apply_error")
 					return
 				}
 
@@ -1227,32 +1402,40 @@ func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coin
 
 			if err != nil {
 				log.Warn("Failed to submit GPU batch, falling back to sequential processing", "batchNumber", batchNumber, "error", err)
+				w.maybeLogGPUInactive("hybrid_submission_error")
 				break
 			}
 			if batchApplyErr != nil {
 				log.Warn("GPU batch application failed, aborting GPU pipeline", "batchNumber", batchNumber, "error", batchApplyErr)
+				w.maybeLogGPUInactive("gpu_batch_application_failed")
 				break
 			}
 			if appliedCount > 0 {
 				totalGPUProcessed += appliedCount
 				batchNumber++
-				log.Info("GPU batch completed", "batchNumber", batchNumber-1, "batchSize", len(txBatch), "validated", appliedCount, "duration", batchDuration, "totalGPUProcessed", totalGPUProcessed)
+				w.gpuLogInfo("GPU batch completed", "batchNumber", batchNumber-1, "batchSize", len(txBatch), "validated", appliedCount, "duration", batchDuration, "totalGPUProcessed", totalGPUProcessed)
+				w.recordGPUBatchSuccess(appliedCount, batchDuration)
 			} else {
-				log.Debug("GPU batch produced no applicable transactions", "batchNumber", batchNumber)
+				w.gpuLogDebug("GPU batch produced no applicable transactions", "batchNumber", batchNumber)
 				// GPU batch processing completed successfully
 				batchNumber++
 			}
 
 			// Check for interrupts between batches
 			if interrupt != nil && atomic.LoadInt32(interrupt) != commitInterruptNone {
-				log.Debug("GPU batch processing interrupted", "totalProcessed", totalGPUProcessed)
+				w.gpuLogDebug("GPU batch processing interrupted", "totalProcessed", totalGPUProcessed)
 				break
 			}
 		}
 
 		if totalGPUProcessed > 0 {
-			log.Info("Multi-batch GPU processing completed", "totalBatches", batchNumber-1, "totalGPUProcessed", totalGPUProcessed)
+			w.gpuLogInfo("Multi-batch GPU processing completed", "totalBatches", batchNumber-1, "totalGPUProcessed", totalGPUProcessed)
+			w.flushGPUSummary("block_end")
+		} else {
+			w.maybeLogGPUInactive("gpu_no_batches_processed")
 		}
+	} else {
+		w.maybeLogGPUInactive("gpu_pipeline_disabled")
 	}
 
 	// Continue with sequential processing for remaining transactions
@@ -1715,7 +1898,7 @@ func (w *worker) updateBatchPerformance(batchSize int, duration time.Duration) {
 	// Log performance for monitoring
 	if duration > 0 {
 		tps := float64(batchSize) / duration.Seconds()
-		log.Debug("GPU batch performance",
+		w.gpuLogDebug("GPU batch performance",
 			"batchSize", batchSize,
 			"duration", duration,
 			"tps", tps,
@@ -1748,6 +1931,15 @@ func (w *worker) GetMinerStats() map[string]interface{} {
 			"cpu_utilization":      hybridStats.CPUUtilization,
 			"gpu_utilization":      hybridStats.GPUUtilization,
 			"load_balancing_ratio": hybridStats.LoadBalancingRatio,
+		}
+
+		gpuStatus := w.hybridProcessor.GetGPUStatus()
+		stats["gpu_status"] = map[string]interface{}{
+			"configured":         gpuStatus.ConfigEnabled,
+			"available":          gpuStatus.Available,
+			"type":               gpuStatus.Type.String(),
+			"device_count":       gpuStatus.DeviceCount,
+			"unavailable_reason": gpuStatus.UnavailableReason,
 		}
 	}
 


### PR DESCRIPTION
## Summary
- track last GPU batch activity and failure details inside the GPU processor and expose them through the hybrid GPU status snapshot for operators
- add miner-side GPU activation and periodic summary logging that aggregates batch counts, throughput, and inactivity flushes to surface when the accelerator stalls

## Testing
- `go test ./...` *(fails: pattern ./...: directory prefix . does not contain main module or its selected dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68cd3bb82650832488c14d0f18cd1b51