### PR TITLE
Disable GPU logging to reduce overhead

### DIFF
--- a/Core-Blockchain/node_src/common/gpu/gpu_processor.go
+++ b/Core-Blockchain/node_src/common/gpu/gpu_processor.go
@@ -11,10 +11,8 @@ import (
 	"unsafe"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/logging"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/log"
 )
 
 /*
@@ -70,6 +68,16 @@ void cleanupCUDA() {
 }
 */
 import "C"
+
+type noopLogger struct{}
+
+func (noopLogger) Trace(string, ...interface{}) {}
+func (noopLogger) Debug(string, ...interface{}) {}
+func (noopLogger) Info(string, ...interface{})  {}
+func (noopLogger) Warn(string, ...interface{})  {}
+func (noopLogger) Error(string, ...interface{}) {}
+
+var log = noopLogger{}
 
 // GPUType represents the type of GPU acceleration
 type GPUType int
@@ -970,13 +978,6 @@ func (p *GPUProcessor) processTransactionsGPU(batch *TransactionBatch) {
 		"deviceCount", p.deviceCount,
 	)
 
-	// Save to GPU log file
-	logging.LogGPU("INFO", "GPU TRANSACTION PROCESSING ACTIVATED",
-		"batchSize", len(batch.Transactions),
-		"gpuType", p.gpuType,
-		"deviceCount", p.deviceCount,
-	)
-
 	log.Debug("Starting enhanced GPU transaction processing",
 		"batchSize", len(batch.Transactions),
 		"gpuType", p.gpuType,
@@ -1226,38 +1227,6 @@ func (p *GPUProcessor) processTransactionsGPU(batch *TransactionBatch) {
 		"cpuSigVerifyTime", cpuSigTime,
 		"totalProcessingTime", totalTime,
 		"timestamp", time.Now().Format("2006-01-02 15:04:05.000"),
-	)
-
-	// Save enhanced performance data to files
-	logging.LogGPU("INFO", "ENHANCED GPU TRANSACTION BATCH COMPLETED",
-		"batchSize", count,
-		"validTransactions", validCount,
-		"successfulExecutions", successCount,
-		"revertedExecutions", revertCount,
-		"outOfGasExecutions", outOfGasCount,
-		"invalidTransactions", invalidCount,
-		"gpuType", p.gpuType,
-		"batchTPS", tps,
-		"gpuKernelTime", gpuProcessingTime,
-		"totalProcessingTime", totalTime,
-	)
-
-	logging.LogPerformance("INFO", "ENHANCED BATCH PERFORMANCE METRICS",
-		"batchSize", count,
-		"batchTPS", tps,
-		"processingMode", "Enhanced GPU",
-		"kernelTime", gpuProcessingTime,
-		"totalTime", totalTime,
-	)
-
-	logging.LogTransaction("INFO", "ENHANCED TRANSACTION BATCH PROCESSED",
-		"batchSize", count,
-		"validTransactions", validCount,
-		"successfulExecutions", successCount,
-		"revertedExecutions", revertCount,
-		"outOfGasExecutions", outOfGasCount,
-		"invalidTransactions", invalidCount,
-		"processingMode", "Enhanced GPU",
 	)
 
 	log.Debug("Enhanced GPU transaction processing completed successfully",

--- a/Core-Blockchain/node_src/common/hybrid/hybrid_processor.go
+++ b/Core-Blockchain/node_src/common/hybrid/hybrid_processor.go
@@ -10,10 +10,18 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/gopool"
 	"github.com/ethereum/go-ethereum/common/gpu"
-	"github.com/ethereum/go-ethereum/common/logging"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/log"
 )
+
+type noopLogger struct{}
+
+func (noopLogger) Trace(string, ...interface{}) {}
+func (noopLogger) Debug(string, ...interface{}) {}
+func (noopLogger) Info(string, ...interface{})  {}
+func (noopLogger) Warn(string, ...interface{})  {}
+func (noopLogger) Error(string, ...interface{}) {}
+
+var log = noopLogger{}
 
 // LoggingConfig controls how hybrid processor events are emitted.
 type LoggingConfig struct {
@@ -373,16 +381,6 @@ func (h *HybridProcessor) recordStrategyDecision(strategy ProcessingStrategy, ba
 			"adaptiveRatio", adaptiveRatio,
 		)
 
-		// Log strategy changes to file
-		logging.LogHybrid("INFO", "HYBRID STRATEGY CHANGE",
-			"from", previousStrategy.String(),
-			"to", strategy.String(),
-			"reason", reason,
-			"batchSize", batchSize,
-			"cpuUtil", cpuUtil,
-			"gpuUtil", gpuUtil,
-			"adaptiveRatio", adaptiveRatio,
-		)
 	}
 
 	if !shouldLogDetail || !h.debugLogsEnabled() {
@@ -722,33 +720,11 @@ func (h *HybridProcessor) updateStats(cpuProcessed, gpuProcessed uint64, duratio
 	if shouldWarn {
 		log.Warn("Hybrid throughput below target", "strategy", strategy.String(), "tps", currentTPS, "target", h.config.ThroughputTarget, "avgLatency", avgLatency, "cpuProcessed", cpuProcessed, "gpuProcessed", gpuProcessed, "duration", duration, "loadRatio", loadRatio)
 
-		// Log performance warnings to file
-		logging.LogPerformance("WARN", "HYBRID THROUGHPUT BELOW TARGET",
-			"strategy", strategy.String(),
-			"currentTPS", currentTPS,
-			"targetTPS", h.config.ThroughputTarget,
-			"avgLatency", avgLatency,
-			"cpuProcessed", cpuProcessed,
-			"gpuProcessed", gpuProcessed,
-			"duration", duration,
-			"loadRatio", loadRatio,
-		)
 	}
 
 	if shouldCheer {
 		log.Info("Hybrid throughput met target", "strategy", strategy.String(), "tps", currentTPS, "target", h.config.ThroughputTarget, "avgLatency", avgLatency, "cpuProcessed", cpuProcessed, "gpuProcessed", gpuProcessed, "duration", duration, "loadRatio", loadRatio)
 
-		// Log performance successes to file
-		logging.LogPerformance("INFO", "HYBRID THROUGHPUT TARGET ACHIEVED",
-			"strategy", strategy.String(),
-			"currentTPS", currentTPS,
-			"targetTPS", h.config.ThroughputTarget,
-			"avgLatency", avgLatency,
-			"cpuProcessed", cpuProcessed,
-			"gpuProcessed", gpuProcessed,
-			"duration", duration,
-			"loadRatio", loadRatio,
-		)
 	}
 }
 


### PR DESCRIPTION
## Summary
- silence the GPU processor by replacing its dependency on the shared logger with an internal no-op implementation
- remove GPU and hybrid processor file logging hooks so the acceleration paths stop emitting disk-heavy telemetry
- stop the hybrid processor from invoking the shared logger so GPU-related workflow runs without log chatter

## Testing
- `go test ./common/hybrid` *(fails: requires OpenCL headers that are not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd5ffeda60832483f9433298af816f